### PR TITLE
fix(issue-templates): correct validations indentation on dropdown fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -77,7 +77,7 @@ body:
         - High (feature broken, no workaround)
         - Medium (feature broken, has workaround)
         - Low (cosmetic, minor inconvenience)
-      validations:
+    validations:
       required: true
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -32,7 +32,7 @@ body:
         - Test coverage / Quality
         - Accessibility hardening
         - Security
-      validations:
+    validations:
       required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/Team-Centinela/Project-save-me-of-the-riwi/security/advisories/new
     about: Report a security vulnerability privately. Please do not open a public issue for security.
   - name: Cineteca Project Guide
-    url: https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md
+    url: https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/README.md
     about: Read the full project specification and evaluation criteria before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -101,7 +101,7 @@ body:
         - P1 — High (next sprint)
         - P2 — Medium (this release)
         - P3 — Low (whenever)
-      validations:
+    validations:
       required: true
 
   - type: dropdown


### PR DESCRIPTION
## Summary

Fixes the issue forms for **Bug Report**, **Chore / Tech Debt**, and **Feature Request**, which were all being rejected by GitHub with:

```
body[7]: validations is not a permitted attribute
body[7]: required is not a permitted attribute
```

## Root cause

In all three templates, the `validations:` block on one of the **required dropdowns** (severity / category / priority) was indented under `attributes:` instead of being a sibling of it. Per [GitHub's form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema), `validations` is a top-level key on a body element (sibling of `type`, `id`, `attributes`), not a nested attribute.

The YAML parser was therefore producing something like:

```yaml
- type: dropdown
  attributes:
    options: [...]
    validations: null   # invalid attribute
    required: true      # invalid attribute
  # validations block missing entirely
```

…which is exactly the `validations is not a permitted attribute` / `required is not a permitted attribute` pair GitHub was reporting.

The other fields in the same files (textareas, inputs) already had `validations:` correctly placed, so only the dropdowns were broken.

## Changes

| File | Fix |
| --- | --- |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Move `validations:` out of `attributes:` on the **Severity** dropdown |
| `.github/ISSUE_TEMPLATE/chore.yml` | Move `validations:` out of `attributes:` on the **Category** dropdown |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Move `validations:` out of `attributes:` on the **Priority** dropdown |
| `.github/ISSUE_TEMPLATE/config.yml` | `Cineteca Project Guide` contact link pointed to a non-existent `Cineteca.md` (silent 404). Repointed to the existing `README.md` |

## Verification

Parsed all three templates with a YAML loader after the change and confirmed:

- No `validations` or `required` keys leak into any `attributes:` block.
- The `validations:` block on the previously broken dropdowns is now a sibling of `attributes:`, matching the schema.
- `config.yml` still parses as a valid issue form config.

After merge, the three templates should appear in the issue chooser without validation errors and the required dropdowns should enforce selection on form submission.