### PR TITLE
docs: add Cineteca and Baseline project guides

### DIFF
--- a/Cineteca.md
+++ b/Cineteca.md
@@ -1,0 +1,319 @@
+# Cineteca — App web
+
+**Descubrimiento de cine y biblioteca personal · cliente web (solo consumo de API)**
+
+> **Guía del proyecto.** Dice *qué* se construye y *por qué* cada decisión importa. El paso a paso técnico —comandos, archivos, configuración— vive en la **Guía Técnica**. Aquí no hay una sola línea de código a propósito: si una decisión no se puede explicar con palabras, todavía no está entendida.
+
+---
+
+## El encargo
+
+Un cineclub los contrató para construir **Cineteca**: una app web donde la gente descubre películas y arma su propia biblioteca — lo que quiere ver, lo que ya vio, listas temáticas que puede compartir por enlace.
+
+El catálogo ya existe. Es **TMDB**, una API REST pública con quince años de historia y millones de fichas mantenidas por una comunidad. Ustedes no construyen servidor ni base de datos: consumen la API y construyen la experiencia.
+
+Tienen **una semana**. Al cierre, alguien que nunca vio la app tiene que poder abrir un enlace, filtrar el catálogo, buscar por texto, abrir una ficha, guardar películas en su biblioteca y compartir la URL exacta de lo que está viendo — sin que nada se rompa cuando la red se caiga, cuando falte un dato o cuando el navegador esté en alemán.
+
+### El foco, y lo que queda fuera desde el primer día
+
+Este proyecto enseña **una sola cosa bien**: consumir una API ajena con criterio. Validar lo que llega, tratar la caché como una copia que caduca, modelar los estados imposibles fuera del tipo y cubrir los cuatro caminos de cada pantalla.
+
+Por eso **no hay cuentas, ni inicio de sesión, ni roles, ni permisos**. No es que no importen: es que en siete días multiplican la complejidad accidental y tapan la lección de fondo. La biblioteca del usuario vive en **su navegador**, y eso —lejos de ser un atajo— trae su propio problema interesante: el almacenamiento local es otro borde no confiable, y se valida al leer con el mismo rigor que una respuesta de red.
+
+---
+
+## El dominio: estados, dinero y ausencias
+
+El dominio es TypeScript puro: no sabe que existe React, ni Axios, ni el navegador. Eso es lo que lo hace barato de probar y lo que permite exigirle el 100% de cobertura sin dolor.
+
+**Los estados, como conjuntos cerrados de variantes.** El estado de una película y la fiabilidad de su valoración se modelan con uniones discriminadas, y cada rama trae **exactamente** los datos que le corresponden. Al consumirlas, un `switch` con un caso por defecto que el compilador considere inalcanzable obliga a cubrir todas las variantes.
+
+**Las ausencias, explícitas en el tipo.** Ningún `0` ni ninguna cadena vacía de TMDB sobrevive al borde: se traducen a "no hay dato" en el mismo sitio donde se valida la respuesta. De ahí para dentro, el tipo dice la verdad y la pantalla está obligada a tratar el caso.
+
+**El dinero, en enteros.** Un presupuesto no es un número con decimales flotantes —esa aritmética pierde céntimos— sino una cantidad entera en la unidad menor de su moneda, acompañada de la moneda. Tres cosas que hay que interiorizar:
+
+- **Nunca un decimal flotante para dinero.** Enteros en unidades menores, siempre.
+- **Moneda y locale son cosas distintas.** La moneda es un dato de la película (TMDB reporta en dólares); el formato es preferencia de quien mira. Los mismos 63 millones se ven `$63,000,000` con el navegador en inglés de Estados Unidos y `63.000.000 $` con el navegador en alemán, y las dos son correctas.
+- **El formateo no se escribe a mano.** Números, monedas, fechas y plurales los resuelve la API de internacionalización del navegador. Un separador de miles puesto con `replace` es un bug esperando un idioma.
+
+**Las dos reglas que van en el README:** prohibido un número que represente dinero fuera del tipo `Money`; prohibido un `0` que signifique "no lo sé".
+
+---
+
+## El contrato con la API que consumen
+
+**Base:** `https://api.themoviedb.org/3` · **Imágenes:** `https://image.tmdb.org/t/p/{tamaño}{ruta}`, donde el catálogo de tamaños lo entrega el propio endpoint de configuración.
+
+**Credencial.** La app manda una credencial de **solo lectura** en cada petición. Va dentro del bundle, así que es pública: por eso se usa una cuenta de práctica y se puede rotar en un minuto. Compilen la app y busquen la cadena dentro de los archivos generados — la van a encontrar, y ese hallazgo va documentado en el README.
+
+**Errores.** TMDB responde con un código propio que **no coincide** con el código HTTP: "recurso no encontrado" es su código 34 con un 404, y "página inválida" es su código 22 con un 400. Esa traducción se hace una sola vez, en el borde, y de ahí para dentro nadie vuelve a ver un error crudo de la librería HTTP.
+
+**Paginación.** Por número de página, 20 resultados por página y **un tope duro de 500 páginas**: la API no sirve más allá, aunque diga que hay novecientas. Ese tope no es un detalle, es una regla de negocio que su paginación infinita tiene que respetar.
+
+**Límite de tasa.** Unas 50 peticiones por segundo por IP. Ante un `429`, respetar la espera que indica el servidor.
+
+| Endpoint | Para qué |
+|---|---|
+| `GET /configuration` | Base y tamaños de imagen. Se pide una vez y se cachea para siempre |
+| `GET /genre/movie/list` | Catálogo de géneros para los filtros |
+| `GET /discover/movie` | **Descubrimiento con filtros**: género, año, nota mínima, votos mínimos, orden |
+| `GET /search/movie` | Búsqueda por texto |
+| `GET /movie/{id}` | Ficha completa. Con el parámetro de expansión trae elenco y tráilers **en la misma petición** |
+| `GET /movie/{id}/recommendations` | Recomendadas, para la sección inferior de la ficha |
+| `GET /trending/movie/week` | Portada de la pantalla de inicio |
+
+Siete endpoints. Toda la dificultad del proyecto está en cómo los consumen, no en cuántos son.
+
+> **El parámetro de expansión merece su párrafo.** Sin él, pintar una ficha son cuatro viajes a la red; con él, uno. Con el límite de tasa de TMDB y un aula entera compartiendo IP, esa diferencia se nota.
+
+---
+
+## Las pantallas y los cuatro estados
+
+Toda pantalla que muestra datos tiene **cuatro caminos, no uno**. En un buscador, el estado vacío no es un caso raro: es lo que ve la mitad de la gente que filtra demasiado.
+
+| Estado | Qué se muestra |
+|---|---|
+| **Carga** | Un esqueleto con la forma de las tarjetas reales, no un indicador giratorio centrado. El esqueleto comunica qué va a aparecer y evita que el diseño salte cuando llegan los datos |
+| **Error** | Lenguaje llano y un botón de reintento. "No pudimos cargar las películas", no "Error 500". Si es límite de tasa: "vamos demasiado rápido, reintentando en 3 s" |
+| **Vacío inicial** | "Tu cineteca está vacía", con un enlace a explorar. Un vacío sin salida es un callejón |
+| **Vacío por filtro** | "Ninguna película coincide con estos filtros", con un botón para **limpiarlos**. Convertir el callejón en una acción es la mitad del trabajo de experiencia de usuario de este proyecto |
+
+**La tarjeta de película** tiene tres niveles de jerarquía, no uno: el título en semibold, el año y la duración atenuados, y la valoración en su propio nivel tipográfico con su recuento y su plural correcto. El estado nunca se comunica solo con color: una película sin estrenar lleva una etiqueta con texto, no solo un borde gris. Y el póster reserva su proporción **antes** de cargar, para que la cuadrícula no salte.
+
+**Las pantallas y su relación con la URL:**
+
+- **Inicio** — tendencias de la semana y acceso a explorar.
+- **Explorar** — filtros y resultados. **Los filtros viven en la URL**, no en el estado del componente: recargar mantiene la vista y compartir el enlace la reproduce exacta en otro navegador.
+- **Búsqueda** — texto libre con espera antes de consultar.
+- **Ficha de película** — ruta con identificador, pensada para compartirse. Es la URL que la gente manda por chat, así que es una función central del producto, no un extra.
+- **Mi cineteca** — lo guardado, y las listas locales con su detalle.
+
+**El estado de la vista vive en la URL; el estado del servidor vive en la caché.** Entre los dos no queda casi nada, y eso explica por qué en este proyecto no hay un almacén global de estado.
+
+Y un detalle que casi nadie hace: **la URL también es un borde no confiable.** Un filtro con un valor absurdo escrito a mano no puede romper la pantalla; se valida igual que una respuesta de red y se cae con elegancia a los valores por defecto.
+
+---
+
+## Formatos y accesibilidad
+
+**Hay dos internacionalizaciones distintas y confundirlas cuesta un día.** El **contenido** (títulos, sinopsis) lo traduce TMDB si se le pide el idioma en la petición. Los **formatos** (fechas, números, dinero, duraciones, plurales) los resuelve el navegador. Y los **textos de la interfaz** son de ustedes: viven en un módulo de textos, y ninguna cadena visible se escribe suelta dentro de un componente.
+
+La trampa que sale en la evaluación: **la traducción que no existe.** Si la sinopsis llega vacía porque TMDB no la tiene en español, eso no es un error de red ni un hueco: es un estado del producto. Se ofrece la versión en inglés con un aviso claro. Ahí se ve la diferencia entre una app internacional y una traducida a medias.
+
+**Accesibilidad y pruebas son el mismo trabajo:** si un test encuentra un botón por su rol y su nombre, un lector de pantalla también lo encuentra; si hace falta un identificador de prueba para localizarlo, ese botón tampoco es accesible.
+
+- Una tarjeta es **un** enlace con nombre accesible completo: "El padrino, 1972, 8,7 de 10".
+- Al cambiar de ruta, el título del documento cambia y el foco va al encabezado. Sin eso, el lector de pantalla sigue leyendo la página anterior.
+- Los errores de formulario se **anuncian**, no solo se pintan en rojo, y el foco salta al primer campo inválido.
+- Contraste suficiente en todo el texto, incluido el que va sobre un póster, y ningún estado comunicado solo con color.
+- La app aguanta zoom al 200% sin cortes ni scroll horizontal.
+- Todo se alcanza con el teclado. La prueba honesta: guarden el ratón en un cajón y recorran la app entera.
+
+---
+
+## El stack completo
+
+Las versiones son las estables verificadas contra el registry de npm el 19 de agosto de 2026. **La tabla es una foto; el registry es la verdad**: verifíquenlas antes de instalar y usen la última estable que el resto del ecosistema soporte — nunca versiones de prueba.
+
+| Capa | Herramienta | Versión | Por qué |
+|---|---|---|---|
+| Build | **Vite** | 8.2.1 | Arranque instantáneo, recarga en caliente real, build optimizado sin configurar |
+| Lenguaje | **TypeScript** (estricto) | **6.0.3** | **No la 7**: el linter con reglas de tipo todavía no la admite, y ese linter es quien impone la arquitectura. Simbiosis antes que novedad |
+| UI | **React** | 19.2.8 | — |
+| Rutas | **React Router** | 8.3.0 | Rutas anidadas, estado en la URL, carga por ruta |
+| Estilos | **Tailwind CSS** | 4.3.3 | Tokens de diseño en el CSS, sin archivo de configuración |
+| Variantes | **cva** + **tailwind-merge** + **clsx** | 0.7.1 / 3.6.0 / 2.1.1 | Variantes tipadas y fusión de clases sin colisiones |
+| Datos remotos | **TanStack Query** | 5.101.4 | Caché, revalidación, paginación infinita, mutaciones optimistas |
+| Transporte | **Axios** | 1.19.0 | Una sola instancia, interceptores, cancelación |
+| Validación | **Zod** | 4.4.3 | El schema es el tipo. Valida la red, el almacenamiento local y los formularios |
+| Formularios | **React Hook Form** + resolvers | 7.85.0 / 5.9.1 | Renders mínimos; el mismo schema valida y tipa |
+| Virtualización | **@tanstack/react-virtual** | 3.14.10 | Memoria constante con miles de tarjetas |
+| Iconos | **lucide-react** | 1.33.0 | Ligero y con importación selectiva |
+| Errores de UI | **react-error-boundary** | 6.1.3 | Un error de render no deja la pantalla en blanco |
+| Pruebas | **Vitest** + **Testing Library** + **MSW** | 4.1.11 / 16.3.2 / 2.15.0 | Dominio en unitarias, componentes por rol accesible, red simulada en el borde |
+| Calidad | **ESLint** + **typescript-eslint** + **Prettier** | 10.8.1 / 8.67.0 / 3.9.6 | Cero advertencias toleradas |
+| Gate | **Husky** + **lint-staged** + `verify.sh` | 9.1.7 / 17.3.0 | Un commit con un tipo `any` no entra |
+| Paquetes | **pnpm** | 11.22.0 | Instalación rápida y determinista |
+
+**Opcionales, si hacen falta:** las devtools de TanStack Query (ver la caché en vivo vale un día de depuración), el plugin de ESLint para Query, el plugin de accesibilidad para JSX y `axe-core` para automatizar una parte del repaso de accesibilidad.
+
+**Fuera de la lista a propósito:** Redux, Zustand, Jotai. **El estado del servidor lo lleva la caché de Query; el estado de la vista, la URL; la biblioteca, su propio módulo de almacenamiento.** Si al final de la semana necesitan un almacén global, hay algo mal modelado, y esa conversación es parte del ejercicio.
+
+---
+
+## Estructura del proyecto
+
+Clean Architecture, con **la regla de dependencia protegida por el linter**: las dependencias apuntan hacia dentro y el dominio no sabe que existe React.
+
+- **`domain/`** — TypeScript puro. Entidades, estados, políticas, schemas de validación, formateadores, errores. Cero imports de React, de Axios y de la caché.
+- **`application/`** — casos de uso y **puertos**: las interfaces de "algo que trae películas" o "algo que guarda la biblioteca", sin saber cómo lo hacen.
+- **`infrastructure/`** — **implementa** los puertos: el cliente HTTP con sus interceptores, un módulo por recurso que valida lo que llega, y el adaptador del almacenamiento del navegador.
+- **`presentation/`** — React y solo React: rutas, componentes, hooks de datos, proveedores y el módulo de textos.
+
+La duda real de la semana no es qué carpetas hay, sino **dónde va este archivo**. La regla de bolsillo: si un archivo del dominio necesitara instalar algo para funcionar, está en la carpeta equivocada.
+
+**La demostración de 60 segundos:** importen un hook de React dentro del dominio y miren caer el linter. Una regla de arquitectura que solo vive en un diagrama se rompe el jueves; una que vive en el linter y en el CI, no.
+
+---
+
+## Reglas del juego
+
+**El código en inglés, la interfaz en español.** Identificadores, archivos, ramas, commits y tests en inglés. El texto que ve el usuario vive en el módulo de textos.
+
+**Nada entra a `main` sin el gate.** Un solo script corre formato, linter, tipos, pruebas con umbral de cobertura y build — el mismo archivo en su máquina y en el CI, para que no puedan separarse. Tiene presupuesto de tiempo: rápido antes de cada commit, completo antes de cada push. Un gate lento acaba en un `--no-verify` el viernes a las diez de la noche, y ahí lo perdieron.
+
+**Cobertura: 100% en el dominio, 80% global.** El dominio es puro y barato de cubrir. Si un archivo del dominio es difícil de probar, el problema es el diseño, no el test.
+
+**Si no lo pueden explicar, no lo entregan.** Examen oral aleatorio. No poder explicar una función propia línea a línea cuenta como no entregada, por bien que funcione la app.
+
+**El borde se valida siempre, y hay tres bordes:** la red, el almacenamiento local y la URL. Ninguno es de fiar.
+
+**Atribución a TMDB, obligatoria.** Los términos de uso exigen mostrar el logo y la frase correspondiente. No es un detalle estético: es la licencia bajo la que consumen el servicio. Va en el pie de página desde el día 1.
+
+---
+
+## Fuera del alcance
+
+No trabajen en esto, aunque les sobre tiempo:
+
+- **Cuentas, inicio de sesión, roles y permisos.** Es la exclusión deliberada del proyecto: la biblioteca vive en el navegador.
+- **Sincronizar la biblioteca entre dispositivos** o cualquier forma de nube propia.
+- **Un backend o un proxy propio** para ocultar la credencial de lectura.
+- **Series de TV** como sección con pantallas dedicadas.
+- **Modo sin conexión persistente** con service worker.
+
+Si terminan el alcance base, vayan hacia **profundidad, no hacia funciones nuevas**: más estados cubiertos, mejor accesibilidad, más casos límite probados, un buscador más robusto ante la red mala.
+
+---
+
+## Ritmo de la semana
+
+El detalle operativo —comandos, archivos, orden exacto— está en la **Guía Técnica**. Esta es la vista de producto.
+
+| Día | Objetivo | Entregable demostrable |
+|---|---|---|
+| **1** | Cimientos y dominio | Proyecto creado, gate en verde, estados y políticas **con sus pruebas**, sin una sola pantalla |
+| **2** | Primer corte vertical | Explorar con datos reales, sus cuatro estados y los filtros en la URL |
+| **3** | Búsqueda y ficha | Ficha completa con las ausencias visibles como "sin dato", búsqueda con espera, imágenes en el tamaño correcto |
+| **4** | La biblioteca local | Guardar y quitar con vuelta atrás, y el almacenamiento validado al leer |
+| **5** | Listas y formularios | Crear y editar listas locales con formulario validado, con sus dos motivos de bloqueo |
+| **6** | Endurecer | Virtualización, accesibilidad, formatos por locale, cobertura |
+| **7** | Entregar | README, despliegue, repaso del checklist y ensayo del oral |
+
+**La regla del día 1 es la que más cuesta respetar y la que más rinde:** no se pinta nada hasta que el dominio esté modelado y probado. Un día "sin pantallas" se siente improductivo y es el que sostiene los otros seis. Los equipos que se lo saltan llegan al día 5 con la misma regla escrita en cuatro componentes distintos.
+
+---
+
+## Criterios de evaluación
+
+Se evalúa en tres momentos: **el repositorio** (código y commits), **la demo** (10 minutos en un navegador, con la red estrangulada a propósito) y **el oral** (preguntas al azar sobre su propio código). Un mismo trabajo puede sacar 9 en la demo y 3 en el oral: es el mismo esfuerzo mal repartido.
+
+| # | Dimensión | Peso | Qué se mira exactamente |
+|---|---|:--:|---|
+| 1 | **Arquitectura y límites** | 20% | La regla de dependencia se cumple y **el linter la impone**. Ningún componente conoce la librería HTTP. Los puertos existen y las pruebas usan dobles de esos puertos, no de librerías |
+| 2 | **Modelado del dominio y ausencias** | 15% | Uniones discriminadas donde hay estados; los `switch` cubiertos por el compilador; ningún `0` ni cadena vacía de TMDB sobrevive al borde; el dinero en enteros |
+| 3 | **Validación de los tres bordes** | 10% | Red, almacenamiento local y URL, los tres validados. Cero afirmaciones de tipo sin comprobar, cero `any`. Se prueba en vivo: se rompe una respuesta simulada y se mira qué hace la app |
+| 4 | **Datos remotos y caché** | 15% | Claves jerárquicas; filtros normalizados; frescura justificada por tipo de dato; mutación optimista con cancelación, vuelta atrás e invalidación **cruzada**; sin reintentos inútiles; paginación infinita que respeta el tope de la API |
+| 5 | **Formularios** | 10% | Un solo schema que valida y tipa; errores accesibles y en español; envío bloqueado mientras vuela; cada motivo de bloqueo con su propio mensaje, nunca un "no se puede" genérico |
+| 6 | **UI, cuatro estados y accesibilidad** | 15% | Los cuatro estados en **cada** vista con datos; navegación completa por teclado; foco visible; zoom al 200%; contraste suficiente; nada comunicado solo con color |
+| 7 | **Pruebas** | 10% | 100% en el dominio, 80% global. Pruebas que describen comportamiento, no implementación. Deterministas: reloj controlado, cero esperas reales. Un test que nunca falla no prueba nada |
+| 8 | **Proceso y entrega** | 5% | Gate en verde en el CI; commits pequeños; cero `--no-verify`; README que un extraño puede seguir; atribución a TMDB presente |
+
+**Escala por dimensión:** 4 cumple, está probado **y saben explicar la decisión y la alternativa que descartaron** · 3 cumple y está probado, con justificación superficial · 2 funciona en el camino feliz y se cae en un caso límite previsible · 1 presente pero mal aplicado (validar unos endpoints y otros no) · 0 ausente.
+
+Nota final = suma de (nivel ÷ 4 × peso). **Se aprueba con 70%** y con la condición de que ninguna dimensión esté en 0.
+
+### Descalificadores automáticos
+
+Da igual lo bonita que quede la app:
+
+- Un `any` sin comentario que lo justifique, o una supresión muda del compilador.
+- Un `--no-verify` en el historial, o un gate debilitado para que pase.
+- Una respuesta de la API consumida con una afirmación de tipo en vez de validarla.
+- La misma regla decidida en dos sitios: el dominio y un componente.
+- Ausencia de la atribución a TMDB.
+- No poder explicar una función propia en el oral.
+
+### Preguntas típicas del oral
+
+Que sirvan también de guía de estudio: *¿por qué se cancela lo que está en vuelo antes de una actualización optimista?* · *enséñenme la línea exacta donde un `0` de TMDB deja de significar cero* · *¿qué se rompe si el texto del buscador entra crudo en la clave de caché?* · *¿por qué la fecha actual entra por parámetro en la política y no se consulta dentro?* · *si mañana TMDB añade un estado nuevo, ¿qué archivo deja de compilar?* · *¿por qué el almacenamiento local se valida al leer, si lo escribió su propia app?* · *¿qué otras vistas muestran el dato que acaban de mutar?*
+
+---
+
+## Criterios de aceptación · Definition of Done
+
+Se verifica en un navegador real, con las DevTools abiertas y la red estrangulada.
+
+**Funcional**
+
+- [ ] Los cuatro estados en explorar: carga, error, vacío inicial y vacío por filtro
+- [ ] El vacío por filtro ofrece limpiarlos, y al hacerlo vuelve a haber resultados
+- [ ] Recargar con filtros aplicados reproduce la vista exacta; el enlace funciona en otro navegador
+- [ ] Teclear diez letras dispara **una** petición, no diez (con la pestaña de red abierta)
+- [ ] Un filtro con un valor absurdo escrito a mano en la URL no rompe la pantalla
+- [ ] Volver atrás tras guardar algo muestra el estado nuevo, no el viejo
+
+**Datos y red**
+
+- [ ] Toda respuesta se valida; romper un campo en la simulación produce un error localizado y claro
+- [ ] Un límite de tasa no dispara un bucle de reintentos
+- [ ] Guardar en la biblioteca se ve al instante y **se revierte** si la escritura falla
+- [ ] Quitar algo actualiza también la cuadrícula y la pantalla de la biblioteca
+- [ ] La paginación infinita se detiene con un mensaje al llegar al tope de la API
+- [ ] Un dato corrupto en el almacenamiento local se descarta sin tumbar la app
+
+**Datos incompletos**
+
+- [ ] Un presupuesto desconocido se ve como "Sin dato", nunca como "$0"
+- [ ] Una película sin póster tiene marcador de posición, no un icono roto
+- [ ] Una película sin votos dice "Sin valoraciones", no 0,0
+- [ ] Una valoración con pocos votos se distingue visualmente de una consolidada
+- [ ] Una sinopsis ausente en español ofrece la versión en inglés con su aviso
+
+**Formatos**
+
+- [ ] Duración como "2 h 15 min"; votos con separador de miles y plural correcto
+- [ ] Fechas, números y dinero correctos con el navegador en español, en inglés y en alemán
+- [ ] El diseño aguanta el alemán sin romperse
+
+**Accesibilidad**
+
+- [ ] Toda la app es navegable solo con teclado y el foco siempre se ve
+- [ ] Una tarjeta es un enlace con nombre accesible completo
+- [ ] Al cambiar de ruta cambian el título del documento y la posición del foco
+- [ ] Los errores de formulario se anuncian
+- [ ] Zoom al 200% sin cortes ni scroll horizontal; contraste suficiente
+
+**Rendimiento**
+
+- [ ] Scroll fluido con 2.000 tarjetas y memoria que no crece sin techo
+- [ ] Los pósters de la cuadrícula piden el tamaño pequeño, no el original
+- [ ] Sin salto de diseño al cargar las imágenes
+- [ ] Cada ruta se descarga al visitarse; el arranque cabe en el presupuesto
+
+**Entrega**
+
+- [ ] El gate completo en verde, en local y en el CI; `main` protegida
+- [ ] README que un extraño sigue de cero a app corriendo
+- [ ] Desplegada en una URL pública que otra persona abre — incluido un enlace profundo recargado
+- [ ] Atribución a TMDB visible
+
+---
+
+## Cuándo está terminado
+
+Al cierre, su equipo tiene que poder pararse frente a alguien que nunca vio la app, en un navegador real, y mostrarle:
+
+- que puede **explorar el catálogo** con filtros entre miles de resultados, y que el enlace que comparte reproduce exactamente lo que estaba viendo — con los cuatro estados cubiertos;
+- que puede **abrir una ficha** donde un presupuesto desconocido dice "sin dato", una película sin votos no finge un 0,0 y una sin póster no rompe nada;
+- que puede **guardar y organizar** su biblioteca, que el corazón responde antes que el disco y **vuelve solo a su sitio** cuando la escritura falla;
+- que un dato **corrupto o inventado** —en la URL o en el almacenamiento— no tumba la aplicación;
+- que **toda la app se usa con el teclado**, que el lector de pantalla la recorre con sentido y que al 200% de zoom sigue entera;
+- y que otra persona **abre la URL desplegada** y la usa sin que ustedes toquen nada.
+
+Lo que se llevan no es la app: es el criterio para consumir cualquier API con cabeza —validar cada borde, tratar la caché como una copia que caduca, modelar los estados imposibles fuera del tipo, no dejar que un hueco se disfrace de dato— en el siguiente proyecto, con otro dominio y otras herramientas.
+
+---
+
+*Este producto usa la API de TMDB pero no está avalado ni certificado por TMDB.*

--- a/Cinética BaseLine.md
+++ b/Cinética BaseLine.md
@@ -1,0 +1,742 @@
+# Cineteca — Línea base
+
+**Del repositorio vacío al andamio en verde · sin una sola funcionalidad**
+
+> **Qué es y qué no es.** Esta guía termina cuando el proyecto arranca, pasa el gate de calidad y **todavía no hace nada**. No hay dominio, no hay consumo de la API, no hay pantallas: eso pertenece a la guía del proyecto y empieza donde esta acaba. Aquí solo hay dependencias, archivos base, estilos, configuración y comandos.
+>
+> Se hace **una vez, entre todos, en la misma sesión**. Es media jornada. Que cada persona monte su propia línea base es la forma más rápida de tener cinco proyectos distintos el miércoles.
+
+---
+
+## Lo que van a tener al terminar
+
+- [ ] `pnpm dev` sirve una pantalla vacía con el tema aplicado y cero errores en consola
+- [ ] `pnpm check-types` en verde con TypeScript en modo severo
+- [ ] `pnpm lint` en verde, con cero advertencias toleradas
+- [ ] `pnpm test` en verde con una prueba de humo
+- [ ] `bash scripts/verify.sh --full` en verde
+- [ ] Un commit rechazado a propósito, para comprobar que el gate existe de verdad
+- [ ] La estructura de carpetas creada y vacía, esperando el primer archivo del dominio
+- [ ] La credencial de TMDB en `.env.local`, validada al arrancar, y **fuera** del repositorio
+
+---
+
+## Tres reglas antes de empezar
+
+**El orden importa.** Cada paso asume el anterior. Saltarse el linter para "avanzar más rápido" significa reescribir archivos el jueves.
+
+**Cada paso termina en un checkpoint.** Un comando que corren o algo que miran en pantalla. Si no pasa, no avanzan: en este stack los errores no se acumulan, se multiplican.
+
+**Las versiones no se fijan de memoria.** Las de este documento se verificaron contra el registry de npm el **19 de agosto de 2026**. Una tabla de versiones es una foto; el registry es la verdad. Verifíquenlas antes de instalar y usen siempre la última estable que el resto del ecosistema soporte — nunca versiones de prueba (`beta`, `rc`, `canary`, `next`).
+
+Todo comando se corre desde la raíz del proyecto salvo aviso.
+
+---
+
+## Paso 1 · Prerrequisitos
+
+```bash
+node -v            # el LTS activo; si no, instálenlo desde nodejs.org
+corepack enable    # deja que el repositorio fije su gestor de paquetes
+pnpm -v            # 11.22.0 al momento de escribir esto
+git --version
+```
+
+`corepack` existe para que la versión de pnpm la mande el `package.json` y no la máquina de cada uno. Sin eso, un lockfile generado con otra versión produce el clásico "en mi máquina funciona".
+
+En el editor, tres extensiones: **ESLint**, **Prettier** y **Tailwind CSS IntelliSense**, con *formatear al guardar* apuntando a Prettier. Que el editor y el gate digan lo mismo.
+
+---
+
+## Paso 2 · La credencial de TMDB
+
+1. Crear una cuenta **de práctica** en `themoviedb.org` (no la personal de nadie).
+2. Entrar a *Settings → API* y solicitar acceso. Piden un formulario de uso: declaren que es un proyecto educativo sin fines comerciales.
+3. Al aprobarse hay dos credenciales. Copien la segunda, el **API Read Access Token**: sirve igual para las dos versiones de la API, así que hay un solo mecanismo en todo el código en vez de dos.
+
+Checkpoint, antes de seguir:
+
+```bash
+export TMDB_TOKEN="eyJ...tu-read-access-token"
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer $TMDB_TOKEN" \
+  https://api.themoviedb.org/3/configuration
+# Se espera: 200
+```
+
+Si sale `401`, el token está mal copiado — suelen colarse saltos de línea al pegar.
+
+> **Asúmanlo desde ahora:** esta credencial va a acabar dentro del bundle y cualquiera puede leerla. Es de solo lectura, de una cuenta de práctica y rotable en un minuto desde el mismo panel. Eso la hace aceptable **aquí y solo aquí**.
+
+---
+
+## Paso 3 · Crear el proyecto
+
+```bash
+pnpm create vite@latest cineteca --template react-ts
+cd cineteca
+pnpm install
+pnpm dev     # http://localhost:5173 debe cargar la plantilla
+```
+
+Limpien el andamio ahora, porque si no sobrevive hasta producción:
+
+```bash
+rm -f src/App.css src/assets/react.svg public/vite.svg
+```
+
+Dejen `src/App.tsx` con un `<h1>Cineteca</h1>` y nada más. `src/index.css` se vacía: en el paso 6 se convierte en el archivo de tokens del tema.
+
+En `index.html`, dos detalles que después se olvidan: `lang="es"` en la etiqueta `html` y un `<title>` de verdad.
+
+Fijen el toolchain y los scripts en `package.json`:
+
+```jsonc
+{
+  "name": "cineteca",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.22.0",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --max-warnings 0",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "prepare": "husky"
+  }
+}
+```
+
+`--max-warnings 0` es una decisión de fondo, no un detalle: una advertencia que nadie arregla se multiplica hasta que el linter deja de informar. Aquí **una advertencia es un fallo**.
+
+```bash
+git init && git add -A && git commit -m "chore: scaffold vite + react + ts"
+```
+
+**Checkpoint:** `pnpm dev` sirve la página con el título y cero errores en consola.
+
+---
+
+## Paso 4 · TypeScript en modo severo
+
+```bash
+pnpm add -D typescript@6.0.3
+```
+
+**Por qué no la última (7.0.2).** `typescript-eslint@8.67.0` declara en sus dependencias de pares `typescript >=4.8.4 <6.1.0`. Con TypeScript 7, el linter con reglas de tipo deja de funcionar — y ese linter es quien va a imponer la arquitectura en el paso 7. Renunciar al linter para tener el compilador nuevo es un mal negocio. Dejen la nota para acordarse:
+
+```
+// TODO(upgrade): subir a TypeScript 7 cuando typescript-eslint admita >=7 en peerDependencies
+```
+
+En `tsconfig.app.json`, dentro de `compilerOptions`:
+
+```jsonc
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
+  }
+}
+```
+
+| Bandera | Qué evita |
+|---|---|
+| `noUncheckedIndexedAccess` | Acceder al primer elemento de una lista vacía. Con la bandera, ese acceso es "el elemento **o** indefinido" y el compilador obliga a decidir qué pasa cuando no hay nada. La que atrapa más bugs reales en este proyecto |
+| `exactOptionalPropertyTypes` | Que una propiedad opcional acepte el valor "indefinido" explícito. Al construir filtros esa diferencia decide si una clave de caché cambia o no |
+| `noFallthroughCasesInSwitch` | Un caso sin corte que se cuela al siguiente |
+| `verbatimModuleSyntax` | Imports de tipos que sobreviven al build; obliga a marcarlos como tipos |
+| `noUnusedLocals` / `noUnusedParameters` | Código muerto acumulándose durante una semana de prisa |
+
+TypeScript resuelve el alias `@/`, pero el empaquetador no se enteraría. Hay que decírselo también a Vite:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({ plugins: [react(), tsconfigPaths()] });
+```
+
+**Checkpoint:** `pnpm check-types` en verde. Comprueben que las banderas están vivas: declaren una lista vacía, accedan a su primer elemento y confirmen que el compilador se queja. Bórrenlo después.
+
+---
+
+## Paso 5 · Dependencias
+
+### 5.1 Primero el verificador de versiones
+
+```bash
+mkdir -p scripts
+```
+
+```bash
+# scripts/check-versions.sh
+#!/usr/bin/env bash
+# Compara lo instalado contra la última estable del registry y detecta paquetes
+# deprecados. Con --gate sale con error si hay alguno (lo usa verify.sh).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+GATE="${1:-}"
+FAILED=0
+deps=$(node -p "const p=require('./package.json');Object.keys({...p.dependencies,...p.devDependencies}).join('\n')")
+printf '%-38s %-14s %-14s %s\n' PAQUETE INSTALADA ÚLTIMA ESTADO
+while read -r dep; do
+  [ -z "$dep" ] && continue
+  installed=$(node -p "try{require('$dep/package.json').version}catch(e){'?'}" 2>/dev/null || echo '?')
+  latest=$(pnpm view "$dep" version 2>/dev/null || echo '?')
+  deprecated=$(pnpm view "$dep" deprecated 2>/dev/null || true)
+  status="ok"
+  [ -n "$deprecated" ] && { status="DEPRECADO"; FAILED=1; }
+  [ "$installed" != "$latest" ] && [ "$status" = "ok" ] && status="hay $latest"
+  printf '%-38s %-14s %-14s %s\n' "$dep" "$installed" "$latest" "$status"
+done <<< "$deps"
+if [ "$GATE" = "--gate" ] && [ "$FAILED" -ne 0 ]; then
+  echo "✖ Hay dependencias deprecadas. Reemplácenlas por su sucesor documentado."; exit 1
+fi
+```
+
+```bash
+chmod +x scripts/check-versions.sh
+```
+
+### 5.2 Bloque A · Runtime
+
+```bash
+pnpm add react-router@8.3.0 @tanstack/react-query@5.101.4 axios@1.19.0 zod@4.4.3 \
+  react-hook-form@7.85.0 @hookform/resolvers@5.9.1 @tanstack/react-virtual@3.14.10 \
+  lucide-react@1.33.0 react-error-boundary@6.1.3 \
+  clsx@2.1.1 tailwind-merge@3.6.0 class-variance-authority@0.7.1
+```
+
+Dos avisos que cuestan una hora si se descubren solos:
+
+- **React Router 8 se importa desde `react-router`**, no desde `react-router-dom` — ese paquete se quedó en la línea 7. Si encuentran un tutorial con `react-router-dom`, es de la versión anterior.
+- **`@hookform/resolvers` tiene que ser 5 o mayor** para hablar con Zod 4. Con la versión 3 y Zod 4, el conector falla con un error de tipos indescifrable.
+
+### 5.3 Bloque B · Estilos
+
+```bash
+pnpm add -D tailwindcss@4.3.3 @tailwindcss/vite@4.3.3
+```
+
+### 5.4 Bloque C · Pruebas
+
+```bash
+pnpm add -D vitest@4.1.11 @vitest/coverage-v8@4.1.11 jsdom@30.0.1 \
+  @testing-library/react@16.3.2 @testing-library/user-event@14.6.5 \
+  @testing-library/jest-dom@7.0.1 msw@2.15.0 axe-core@4.13.0 \
+  vite-tsconfig-paths@6.1.1
+```
+
+`axe-core` va directo, sin envoltorio: los paquetes que lo envuelven para Vitest están sin mantenimiento, y el envoltorio son doce líneas propias. **La dependencia más pequeña que resuelve el problema.**
+
+### 5.5 Bloque D · Calidad
+
+```bash
+pnpm add -D eslint@10.8.1 typescript-eslint@8.67.0 prettier@3.9.6 \
+  eslint-config-prettier@10.1.8 eslint-plugin-react-hooks@7.1.1 \
+  eslint-plugin-jsx-a11y@6.10.2 @tanstack/eslint-plugin-query@5.101.4 \
+  globals@17.11.0 husky@9.1.7 lint-staged@17.3.0 \
+  @tanstack/react-query-devtools@5.101.4
+```
+
+`eslint-plugin-jsx-a11y` no es decoración: es el único miembro del equipo que se acuerda de la accesibilidad a las once de la noche del día 6.
+
+**Checkpoint:**
+
+```bash
+./scripts/check-versions.sh    # cero deprecados
+pnpm check-types
+git add -A && git commit -m "chore: add project dependencies"
+```
+
+---
+
+## Paso 6 · Tailwind y los tokens del tema
+
+Tailwind 4 es **CSS-first**: no hay archivo de configuración, no hay lista de rutas que mantener, y los tokens viven en el CSS.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({ plugins: [react(), tailwindcss(), tsconfigPaths()] });
+```
+
+```css
+/* src/index.css — el contrato de diseño del proyecto */
+@import "tailwindcss";
+
+@theme {
+  /* Superficies y texto: nombres semánticos, jamás descriptivos */
+  --color-surface:        oklch(0.16 0.02 265);
+  --color-surface-raised: oklch(0.21 0.02 265);
+  --color-ink:            oklch(0.97 0.01 265);
+  --color-ink-muted:      oklch(0.72 0.02 265);
+  --color-brand:          oklch(0.72 0.17 152);
+  --color-danger:         oklch(0.63 0.20 25);
+
+  /* Estados del catálogo: si mañana cambia el ámbar, se toca UNA línea */
+  --color-status-released:   oklch(0.72 0.17 152);
+  --color-status-unreleased: oklch(0.80 0.15 85);
+  --color-status-unknown:    oklch(0.60 0.02 265);
+
+  /* La valoración tiene su propio nivel tipográfico */
+  --text-rating: 1.375rem;
+  --text-rating--line-height: 1.1;
+
+  /* Área táctil mínima con nombre, para que nadie escriba 44px suelto */
+  --spacing-touch: 2.75rem;
+  --radius-card:   0.75rem;
+  --aspect-poster: 2 / 3;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+Tres reglas que nacen aquí y rigen todo el proyecto:
+
+- **Los valores literales de color viven solo en `@theme`.** Un color escrito a mano dentro de un componente es una fuga del contrato de diseño.
+- **Los nombres son semánticos.** `status-unreleased` comunica intención; `amber-500` solo comunica color.
+- **Las clases se fusionan con una utilidad, nunca concatenando cadenas.** Creen un archivo `src/presentation/lib/cn.ts` que combine `clsx` con `tailwind-merge` y expórtenlo como `cn`: son dos líneas y evitan el bug silencioso más común del stack — dos paddings en la misma cadena, gana uno de los dos y nadie sabe cuál.
+
+Asegúrense de que `src/main.tsx` importa `./index.css`.
+
+**Checkpoint:** un elemento con `bg-surface text-ink min-h-touch rounded-card` se ve con los colores del tema. Si sale sin estilo, falta el plugin en `vite.config.ts` o el `@import` en el CSS.
+
+---
+
+## Paso 7 · ESLint y Prettier
+
+Este archivo es el que convierte "Clean Architecture" de un diagrama en una regla ejecutable. Va en **JavaScript** (`eslint.config.js`): la configuración en TypeScript necesita un cargador extra y no vale la pena en la línea base.
+
+```js
+// eslint.config.js
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import query from '@tanstack/eslint-plugin-query';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  { ignores: ['dist', 'coverage'] },
+
+  js.configs.recommended,
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  reactHooks.configs['recommended-latest'],
+  jsxA11y.flatConfigs.recommended,
+  query.configs['flat/recommended'],
+
+  {
+    languageOptions: {
+      globals: globals.browser,
+      parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+    },
+  },
+
+  // ── LA REGLA DE DEPENDENCIA ───────────────────────────────────────────
+  // El dominio es TypeScript puro: no conoce React, ni la librería HTTP, ni
+  // la caché, ni las capas de fuera. Eso es lo que lo vuelve testeable sin
+  // un solo doble de prueba.
+  {
+    files: ['src/domain/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['react', 'react-*', 'axios', '@tanstack/*', 'react-hook-form'],
+            message: 'El dominio no depende de frameworks.' },
+          { group: ['@/presentation/*', '@/infrastructure/*', '@/application/*'],
+            message: 'Las dependencias apuntan hacia dentro.' },
+        ],
+      }],
+    },
+  },
+  {
+    files: ['src/application/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@/presentation/*', '@/infrastructure/*'],
+            message: 'La aplicación define interfaces; la infraestructura las implementa, no al revés.' },
+          { group: ['axios', 'react', 'react-*'],
+            message: 'La aplicación no sabe cómo viajan los datos.' },
+        ],
+      }],
+    },
+  },
+  // La librería HTTP existe en UN solo directorio. Si aparece en otro, el
+  // transporte dejó de ser sustituible.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/infrastructure/http/**'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        paths: [{ name: 'axios', message: 'Solo src/infrastructure/http puede importar axios.' }],
+      }],
+    },
+  },
+
+  { files: ['**/*.spec.{ts,tsx}'], rules: { '@typescript-eslint/no-non-null-assertion': 'off' } },
+  prettier,   // último siempre: apaga lo que Prettier decide
+);
+```
+
+```json
+// .prettierrc.json
+{ "singleQuote": true, "semi": true, "printWidth": 100, "trailingComma": "all" }
+```
+
+### Checkpoint · La demostración de 60 segundos
+
+```bash
+mkdir -p src/domain/shared
+echo "import { useState } from 'react'; export const x = useState;" > src/domain/shared/bad.ts
+pnpm lint    # debe FALLAR: "El dominio no depende de frameworks"
+rm src/domain/shared/bad.ts
+pnpm lint    # debe pasar
+```
+
+Háganlo de verdad, todos, mirando la pantalla. Una regla de arquitectura que solo vive en un diagrama se rompe el jueves; una que vive en el linter y en el CI, no.
+
+---
+
+## Paso 8 · Vitest, Testing Library y MSW
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.spec.{ts,tsx}', 'src/main.tsx', 'src/**/*.d.ts', 'src/test/**'],
+      // Los umbrales se activan en el paso del dominio, cuando ya haya código
+      // propio que cubrir. Encenderlos con el andamio vacío solo enseña a
+      // negociar con el gate.
+      // thresholds: {
+      //   lines: 80, functions: 80, branches: 80, statements: 80,
+      //   'src/domain/**/*.ts': { lines: 100, functions: 100, branches: 100, statements: 100 },
+      // },
+    },
+  },
+});
+```
+
+```ts
+// vitest.setup.ts
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
+import { server } from './src/test/msw/server';
+
+// onUnhandledRequest: 'error' es la línea que hace útil a MSW: una petición que
+// nadie simuló revienta el test en vez de irse a la red de verdad.
+beforeAll(() => { server.listen({ onUnhandledRequest: 'error' }); });
+afterEach(() => { server.resetHandlers(); cleanup(); });
+afterAll(() => { server.close(); });
+
+// jsdom no implementa ninguno de los dos, y el tema y el virtualizador los piden.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false, media: query, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {} unobserve() {} disconnect() {}
+} as unknown as typeof ResizeObserver;
+```
+
+```ts
+// src/test/msw/server.ts
+import { setupServer } from 'msw/node';
+
+// Arranca sin simulaciones a propósito: cada una se añade con la funcionalidad
+// que la necesita, con respuestas reales de la API como base.
+export const server = setupServer();
+```
+
+**Checkpoint:** escriban una única prueba de humo que monte el esqueleto de la app y compruebe que aparece el encabezado. `pnpm test` en verde.
+
+---
+
+## Paso 9 · La estructura de carpetas
+
+```bash
+mkdir -p \
+  src/domain/shared \
+  src/application/ports \
+  src/infrastructure/{http,api,storage} \
+  src/presentation/{routes,components/{ui,feature},hooks,providers,copy,lib} \
+  src/config src/test/msw
+```
+
+Las carpetas quedan vacías. La duda real de la semana no es qué carpetas hay, sino **dónde va este archivo**:
+
+| Lo que están escribiendo | Va en |
+|---|---|
+| Una regla de negocio, un estado, un formateador | `domain/` |
+| La interfaz de "algo que trae datos" o "algo que los guarda" | `application/ports/` |
+| La llamada a la red con su validación | `infrastructure/api/` |
+| El cliente HTTP y sus interceptores | `infrastructure/http/` |
+| El acceso al almacenamiento del navegador | `infrastructure/storage/` |
+| Un hook de datos, un componente, una ruta | `presentation/` |
+| Un texto visible por el usuario | `presentation/copy/` |
+
+**Regla de bolsillo:** si un archivo de `domain/` necesitara instalar algo para funcionar, está en la carpeta equivocada.
+
+---
+
+## Paso 10 · La configuración, validada
+
+El entorno es un borde no confiable como cualquier otro: si falta una variable, la app tiene que morir **al arrancar**, con un mensaje claro, y no tres pantallas después con un error de autorización inexplicable.
+
+```ts
+// src/config/env.ts
+import { z } from 'zod';
+
+const envSchema = z.object({
+  VITE_TMDB_READ_TOKEN: z.string().min(40, 'Falta el API Read Access Token de TMDB'),
+  VITE_TMDB_API_BASE: z.string().url().default('https://api.themoviedb.org'),
+  VITE_TMDB_IMAGE_BASE: z.string().url().default('https://image.tmdb.org/t/p'),
+});
+
+const parsed = envSchema.safeParse(import.meta.env);
+
+if (!parsed.success) {
+  throw new Error(`Configuración inválida:\n${z.prettifyError(parsed.error)}`);
+}
+
+export const env = parsed.data;
+```
+
+```bash
+# .env.example   (SÍ se commitea)
+VITE_TMDB_READ_TOKEN=pon-aqui-tu-api-read-access-token
+```
+
+```bash
+# .env.local     (NUNCA se commitea)
+VITE_TMDB_READ_TOKEN=eyJ...
+```
+
+```bash
+printf '\n.env.local\n.env*.local\ncoverage\n' >> .gitignore
+```
+
+**El prefijo `VITE_` es una advertencia, no burocracia:** Vite solo expone al cliente las variables con ese prefijo, precisamente para que nadie filtre un secreto por accidente. Que su credencial lo lleve significa que es pública.
+
+**Checkpoint:** borren la variable de `.env.local`, corran `pnpm dev` y confirmen que la app muere con el mensaje en español. Devuélvanla.
+
+---
+
+## Paso 11 · El esqueleto de la aplicación
+
+Cuatro archivos base, sin ninguna funcionalidad dentro:
+
+| Archivo | Qué contiene |
+|---|---|
+| `src/main.tsx` | El punto de entrada: importa el CSS, monta React en modo estricto y envuelve la app en los proveedores |
+| `src/presentation/providers/app-providers.tsx` | El proveedor de la caché de datos y el límite de errores de render. Las opciones por defecto de la caché **se dejan para el paso de la capa de datos**: aquí solo se monta |
+| `src/presentation/routes/router.tsx` | El enrutador con una ruta raíz, un contenedor común y una ruta de "no encontrado". Vacías |
+| `src/presentation/routes/root-layout.tsx` | La cabecera, el pie con la atribución a TMDB y el hueco donde se pintarán las páginas |
+
+Tres decisiones que se toman ahora y no se discuten después:
+
+- **React en modo estricto**, desde el principio. Descubrir en el día 5 que un efecto se ejecuta dos veces es un mal día; descubrirlo hoy no cuesta nada.
+- **Un límite de errores de render** desde el primer commit. Un error suelto no puede dejar la pantalla en blanco, y en desarrollo el mensaje ahorra tiempo.
+- **La atribución a TMDB en el pie, ya.** Los términos de uso de la API exigen mostrar el logo y la frase correspondiente. Es la licencia bajo la que consumen el servicio, no un detalle estético — y puesta el primer día, no se olvida el último.
+
+Añadan también las devtools de la caché, condicionadas a que la app corra en desarrollo. Ver la caché en vivo vale un día entero de depuración más adelante.
+
+**Checkpoint:** `pnpm dev` sirve el esqueleto con cabecera y pie, la ruta inexistente muestra la pantalla de "no encontrado", y la consola está limpia.
+
+---
+
+## Paso 12 · El gate
+
+```bash
+# scripts/verify.sh
+#!/usr/bin/env bash
+# =============================================================================
+# verify.sh — EL gate de calidad.
+# Contrato: exit 0 ⇒ formato + linter sin advertencias + tipos estrictos +
+#           pruebas verdes + build + sin dependencias deprecadas.
+# Lo usan: .husky/pre-commit (--quick), .husky/pre-push (--full) y el CI (--full).
+# Nunca se saltea y nunca se debilita un paso "para que pase": se arregla el código.
+# =============================================================================
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:---full}"
+case "$MODE" in --quick|--full) ;; *) echo "uso: verify.sh [--quick|--full]"; exit 2 ;; esac
+
+BLUE='\033[1;34m'; GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+step() { printf '\n%b▶ %s%b\n' "$BLUE" "$1" "$NC"; }
+fail() { printf '\n%b✖ GATE EN ROJO — %s%b\n' "$RED" "$1" "$NC"; exit 1; }
+START=$(date +%s)
+
+step "[1/5] Formato — Prettier"
+pnpm format:check || fail "hay archivos sin formatear (corran: pnpm format)"
+
+step "[2/5] Linter — ESLint, cero advertencias"
+pnpm lint || fail "el linter encontró problemas"
+
+step "[3/5] Tipos — tsc --noEmit"
+pnpm check-types || fail "errores de tipos"
+
+if [ "$MODE" = "--quick" ]; then
+  printf '\n%b✔ GATE RÁPIDO EN VERDE en %ss%b\n' "$GREEN" "$(( $(date +%s) - START ))" "$NC"; exit 0
+fi
+
+step "[4/5] Pruebas — Vitest"
+pnpm test || fail "pruebas rojas o cobertura por debajo del umbral"
+
+step "[5/5] Build de producción"
+pnpm build || fail "el build falló"
+
+bash scripts/check-versions.sh --gate || fail "hay una dependencia deprecada"
+
+printf '\n%b✔ GATE COMPLETO EN VERDE en %ss%b\n' "$GREEN" "$(( $(date +%s) - START ))" "$NC"
+```
+
+```bash
+chmod +x scripts/verify.sh
+pnpm dlx husky init
+printf 'pnpm lint-staged\nbash scripts/verify.sh --quick\n' > .husky/pre-commit
+printf 'bash scripts/verify.sh --full\n'                     > .husky/pre-push
+```
+
+```jsonc
+// package.json
+"lint-staged": {
+  "*.{ts,tsx}": ["eslint --fix --max-warnings 0", "prettier --write"],
+  "*.{json,css,md}": ["prettier --write"]
+}
+```
+
+`lint-staged` arregla y formatea **los archivos del commit**; `verify.sh --quick` comprueba **el proyecto entero**. Son cosas distintas y por eso están los dos.
+
+**Presupuesto de tiempo:** el gate rápido por debajo de 10 s, el completo por debajo de 90 s. Si el gate rápido tarda medio minuto, alguien va a saltárselo el viernes por la noche y ahí lo perdieron. Si se pone lento, se arregla la causa; **no se quitan pasos**.
+
+```yaml
+# .github/workflows/ci.yml
+name: ci
+on:
+  push: { branches: [main] }
+  pull_request:
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: bash scripts/verify.sh --full
+        env:
+          VITE_TMDB_READ_TOKEN: ${{ secrets.VITE_TMDB_READ_TOKEN }}
+```
+
+El CI corre **el mismo archivo** que sus hooks: es la única forma de que local y CI no puedan separarse. Protejan `main` exigiendo este job.
+
+**Checkpoint, el más importante de la guía:** intenten commitear una variable con tipo `any`. El commit debe ser rechazado. Ese "no" es el producto de todo el paso.
+
+---
+
+## Paso 13 · Cerrar la línea base
+
+```bash
+bash scripts/verify.sh --full
+git add -A && git commit -m "chore: project baseline — tooling, theme, tests and quality gate"
+git push -u origin main
+```
+
+Un `README.md` corto, que un extraño pueda seguir sin preguntarles nada: qué es el proyecto, requisitos, cómo obtener la credencial de TMDB, `pnpm install`, crear `.env.local`, `pnpm dev`, cómo correr las pruebas y el gate, y la atribución a TMDB.
+
+Repasen la lista del principio de este documento. Si las ocho casillas están marcadas, la línea base está terminada y **empieza el proyecto**: el primer archivo que se escribe es del dominio, y ese día no se pinta ninguna pantalla.
+
+---
+
+## Comandos de referencia rápida
+
+```bash
+pnpm dev                          # servidor de desarrollo
+pnpm test:watch                   # pruebas en vivo mientras escriben
+pnpm test                         # pruebas + cobertura (lo que corre el gate)
+pnpm lint                         # linter, cero advertencias
+pnpm check-types                  # tipos
+pnpm format                       # formatear
+bash scripts/verify.sh --quick    # lo que corre en cada commit
+bash scripts/verify.sh --full     # lo que corre antes de cada push y en el CI
+./scripts/check-versions.sh       # versiones y deprecaciones
+pnpm build && pnpm preview        # build de producción, servido para medir
+```
+
+---
+
+## Solución de problemas de la línea base
+
+| Síntoma | Causa | Arreglo |
+|---|---|---|
+| `401` al probar la credencial | Token mal copiado o mandado como clave de v3 | Bearer, y revisen saltos de línea al pegar |
+| Las clases de Tailwind no aplican | Falta el plugin o el `@import` | Plugin en `vite.config.ts` y `@import "tailwindcss"` en `src/index.css` |
+| El linter con reglas de tipo no corre | TypeScript 7 con `typescript-eslint` 8 | Fijen TypeScript 6.0.3 (paso 4) |
+| ESLint no encuentra el proyecto de TS | Falta `projectService` o el directorio raíz | Bloque `languageOptions.parserOptions` del paso 7 |
+| El alias `@/` falla en las pruebas | Falta el plugin de rutas en la config de Vitest | `vite-tsconfig-paths` en `vitest.config.ts` |
+| `matchMedia is not a function` | jsdom no lo implementa | El stub del `vitest.setup.ts` (paso 8) |
+| `ResizeObserver is not defined` | Igual | Mismo archivo |
+| MSW: `request not handled` | No hay simulación para esa URL | Añádanla. El error es la característica, no el fallo |
+| Los hooks de git no se ejecutan | Falta el script `prepare` o `husky init` | Paso 3 y paso 12; después, `pnpm install` otra vez |
+| El gate falla por cobertura con el proyecto vacío | Los umbrales están activados antes de tiempo | Siguen comentados hasta el paso del dominio (paso 8) |
+| `pnpm` no es la versión esperada | Corepack deshabilitado | `corepack enable` y `packageManager` en `package.json` |
+
+---
+
+*Este producto usa la API de TMDB pero no está avalado ni certificado por TMDB.*


### PR DESCRIPTION
## Description

Adds the two project guides that the repo references everywhere but doesn't have on disk:

- **`Cineteca.md`** — the *what* and *why* of the project: domain, TMDB contract, screens, four states, formats, accessibility, stack, architecture, scoring criteria, Definition of Done.
- **`Cinética BaseLine.md`** — the *how*: the 13 steps to take the repo from empty to a working gate, with specific tool versions, code snippets, and a troubleshooting table.

Both files have been in the repo from the start as the project's source of truth, but they existed only locally and were never committed. Every issue body in this repo (#1–#24) links to `Cineteca.md` — those links currently 404.

## Why now

- **Fixes broken references.** Closing the gap between what the issues link to and what the repo actually contains.
- **Available before bootstrap starts.** #1 (Bootstrap) can now be opened and read alongside the actual setup guide.
- **No code, no risk.** Two docs files, no behavior change.

## Why no `.gitignore` / no `LICENSE` / no other foundations

Those files have a natural home in issue #1 (Bootstrap Vite + React + TypeScript project). Bundling them here would mix concerns and bypass the issue that's meant to author them. The two docs in this PR are stale — they should land before bootstrap starts so references work.

## Out of scope

- I did **not** rewrite the references from `Cineteca.md` → `README.md` in the existing issue bodies that the previous PR (#25) did in `config.yml`. Issues #1–#24 still link to `Cineteca.md` (now valid after this PR). If we want a future sweep to consolidate to `README.md`, that's a separate decision.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Chore / Maintenance
- [ ] Performance improvement
- [ ] Test only

## How to Test

1. Pull the branch
2. Open `Cineteca.md` and confirm the project spec is intact
3. Open `Cinética BaseLine.md` and confirm the 13-step setup guide is intact
4. Click any link from any issue body to `Cineteca.md` — it should resolve
