### PR TITLE
chore(governance): split docs, add CONTRIBUTING, hybrid merge strategy, Dependabot on develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
     target-branch: develop
     commit-message:
       prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
       include: "scope"
     labels:
       - "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    target-branch: develop
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    labels:
+      - "chore"
+      - "deps"
+      - "backlog"
+    groups:
+      patch-and-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      major-and-security:
+        applies-to: version-updates
+        update-types:
+          - "major"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,13 @@ The repo uses a lightweight Git Flow with two long-lived branches and a handful 
 
 ### Short-lived branches
 
-| Prefix       | Branched from | Merged back into               | Naming                                       |
-| ------------ | ------------- | ------------------------------ | -------------------------------------------- |
-| `feature/`   | `develop`     | `develop`                      | `feature/<scope>-<short-desc>`               |
-| `bugfix/`    | `develop`     | `develop`                      | `bugfix/<scope>-<short-desc>`                |
-| `chore/`     | `develop`     | `develop`                      | `chore/<scope>-<short-desc>`                 |
-| `release/`   | `develop`     | `main` **and** `develop`       | `release/vX.Y.Z`                             |
-| `hotfix/`    | `main`        | `main` **and** `develop`       | `hotfix/<scope>-<short-desc>`                |
+| Prefix       | Branched from | Merged back into               | Naming                                       | Merge strategy                          |
+| ------------ | ------------- | ------------------------------ | -------------------------------------------- | --------------------------------------- |
+| `feature/`   | `develop`     | `develop`                      | `feature/<scope>-<short-desc>`               | **Squash**                              |
+| `bugfix/`    | `develop`     | `develop`                      | `bugfix/<scope>-<short-desc>`                | **Squash**                              |
+| `chore/`     | `develop`     | `develop`                      | `chore/<scope>-<short-desc>`                 | **Squash**                              |
+| `release/`   | `develop`     | `main` **and** `develop`       | `release/vX.Y.Z`                             | **Merge commit** (`--no-ff`)            |
+| `hotfix/`    | `main`        | `main` **and** `develop`       | `hotfix/<scope>-<short-desc>`                | **Merge commit** (`--no-ff`)            |
 
 ### Rules
 
@@ -63,9 +63,81 @@ hotfix/env-validation-crash-on-empty-token
 
 ---
 
+## Merge strategy — hybrid, on purpose
+
+The repo uses a **hybrid** strategy. Not everything squashes, and not everything merges with a real commit. The choice depends on whether the source branch will need to exchange changes with the target again.
+
+### The rule
+
+| Merge direction                     | Strategy                  | Why                                                                                                                |
+| ----------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `feature/*` → `develop`             | **Squash**                | Throwaway branch; nothing will ever merge back into it                                                            |
+| `bugfix/*` → `develop`              | **Squash**                | Same                                                                                                               |
+| `chore/*` → `develop`               | **Squash**                | Same                                                                                                               |
+| `release/*` → `main`                | **Merge commit** (`--no-ff`) | `release/*` is the bridge between `develop` and `main`; both branches need a real shared parent to keep round-tripping clean |
+| `release/*` → `develop`             | **Merge commit** (`--no-ff`) | Same                                                                                                               |
+| `hotfix/*` → `main`                 | **Merge commit** (`--no-ff`) | Same                                                                                                               |
+| `hotfix/*` → `develop`              | **Merge commit** (`--no-ff`) | Same                                                                                                               |
+
+### Why not squash everything?
+
+Squash-merge creates a **brand-new commit** on the target branch with only the target's HEAD as its parent — the source branch's history is collapsed into a single fresh commit. That is fine when the source branch is throwaway. It is **not** fine when the source branch and the target are two long-lived branches that need to keep exchanging changes.
+
+The concrete failure mode:
+
+1. `release/v0.1` is squash-merged into `main` → `main` has a synthetic `S1` commit.
+2. `release/v0.1` is squash-merged into `develop` → `develop` has a synthetic `S2` commit with the same diff as `S1` but **a different commit hash**.
+3. `main` later receives a hotfix `H`.
+4. We try to merge `main` back into `develop`. Git finds no shared ancestor that contains the equivalent of `S2` and tries to re-apply the entire `S2` diff as new work — phantom conflicts, even though nothing has actually changed.
+
+The fix is to use **real merge commits** (`--no-ff`) wherever two long-lived branches cross. A real merge commit has two parents, which keeps the shared ancestry intact for every future round-trip.
+
+### Why the `main` history still looks clean
+
+```bash
+git log --first-parent main
+```
+
+shows only the merge commits on `main` — one line per release. The granular feature commits are still in the object graph (so `git bisect` and archaeology still work) but they don't clutter the high-level log. GitHub's PR diff view for a merge commit shows the same cumulative diff it would show for a squash, so reviewability is the same.
+
+### Repo settings this requires
+
+In **Settings → General → Pull Requests**:
+
+| Setting                                 | Value     |
+| --------------------------------------- | --------- |
+| Allow squash merging                    | enabled   |
+| Allow merge commits                      | **enabled** |
+| Allow rebase merging                    | disabled  |
+| Allow auto-merge                        | enabled   |
+| Automatically delete head branches      | enabled   |
+| Default squash commit message           | PR title  |
+
+In **Settings → Branches → Branch protection** on `main` **and** `develop`:
+
+| Setting                                  | Value          |
+| ---------------------------------------- | -------------- |
+| Require linear history                   | **disabled**   |
+
+"Require linear history" literally forbids merge commits and would force you right back into the squash-only problem. It is deliberately off.
+
+### How to choose the merge button for each PR
+
+- **`feature/*`, `bugfix/*`, `chore/*` → `develop`:** click **Squash and merge**.
+- **`release/*` → `main` and `release/*` → `develop`:** click **Create a merge commit**.
+- **`hotfix/*` → `main` and `hotfix/*` → `develop`:** click **Create a merge commit**.
+
+When squash is used, the PR title becomes the commit message — see the convention in the next section. When a merge commit is used, the PR title becomes the merge commit's subject line; follow the same convention so `git log` on `main` stays meaningful.
+
+### Why Dependabot targets `develop`, not `main`
+
+Most of the `main → develop` traffic in a typical repo is Dependabot opening dep-update PRs against `main`. That traffic is what forces the painful reverse sync in the first place. Pointing Dependabot at `develop` (see `.github/dependabot.yml`) eliminates the round-trip entirely for the common case. The only legitimate `main → develop` merge left is a true emergency hotfix committed straight to `main`, which is rare and handled with a `--no-ff` merge commit just like the others.
+
+---
+
 ## Commit and PR title convention
 
-We follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/). Because the repo uses **squash-merge only** (see below), the **PR title is the commit message** that ends up on `develop` or `main`. Getting the PR title right is the entire commit-message practice here.
+We follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/). For **squash** merges (feature / bugfix / chore → develop), the PR title is the commit message that ends up on `develop`. For **merge-commit** merges (release/* and hotfix/* into main/develop), the PR title becomes the merge commit's subject line. Either way, getting the PR title right is the entire commit-message practice here.
 
 ### Format
 
@@ -156,11 +228,11 @@ interceptors must be ported to axios interceptors.
 4. **Pass the gate locally before pushing.** Run `bash scripts/verify.sh --quick` for the inner loop, `bash scripts/verify.sh --full` before the push. See the [quality gate](#quality-gate) below.
 5. **Open the PR against the correct base.**
    - `feature/*`, `bugfix/*`, `chore/*` → base is `develop`.
-   - `hotfix/*` → base is `main`, then a backport PR from `main` to `develop`.
-   - `release/*` → base is `main` (and a follow-up PR to `develop`).
+   - `release/*` → base is `main` for the release PR, then a second PR from `release/*` back to `develop`.
+   - `hotfix/*` → base is `main`, then a second PR from `hotfix/*` to `develop` (or from `main` to `develop` once the hotfix lands).
 6. **Reference the issues it closes.** Use `Closes #N`, `Fixes #N`, or `Refs #N` in the PR body.
 7. **Request a review.** At least one approval is required to merge (see branch protection).
-8. **Merge with squash.** Only "Squash and merge" is allowed. The PR title becomes the squash commit message. The head branch is deleted automatically after merge.
+8. **Pick the merge button correctly.** See the [merge strategy](#merge-strategy--hybrid-on-purpose) table above. The PR title is the squash / merge-commit subject line, so follow the convention in the next section.
 9. **Never use `--no-verify`.** A gate that can be skipped is not a gate.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,10 +85,10 @@ Squash-merge creates a **brand-new commit** on the target branch with only the t
 
 The concrete failure mode:
 
-1. `release/v0.1` is squash-merged into `main` → `main` has a synthetic `S1` commit.
-2. `release/v0.1` is squash-merged into `develop` → `develop` has a synthetic `S2` commit with the same diff as `S1` but **a different commit hash**.
+1. `release/v0.1` is squash-merged into `main` → `main` has a synthetic `S1` commit whose parent is `main`'s previous HEAD.
+2. `release/v0.1` is squash-merged into `develop` → `develop` has a synthetic `S2` commit whose parent is `develop`'s previous HEAD. `S2` and `S1` carry the same diff but are unrelated commit objects.
 3. `main` later receives a hotfix `H`.
-4. We try to merge `main` back into `develop`. Git finds no shared ancestor that contains the equivalent of `S2` and tries to re-apply the entire `S2` diff as new work — phantom conflicts, even though nothing has actually changed.
+4. We try to merge `main` back into `develop`. Git's merge base between `main` and `develop` is the common ancestor from before `release/v0.1`, so the synthetic `S2` is treated as exclusive work on `develop` that `main` does not have. In practice this manifests one of two ways depending on the configuration: `fatal: refusing to merge unrelated histories` (if `--allow-unrelated-histories` is not set), or a long cascade of **phantom conflicts** as Git tries to re-apply the entire `S2` diff — even though every line of it is already in `main` as `S1`.
 
 The fix is to use **real merge commits** (`--no-ff`) wherever two long-lived branches cross. A real merge commit has two parents, which keeps the shared ancestry intact for every future round-trip.
 
@@ -329,7 +329,11 @@ Before opening, search the existing issues to avoid duplicates. For bugs, reprod
 
 ## References
 
-- **Project guide (what we build and why):** [Cineteca project guide](https://gist.github.com/xXAreizaXx/16cb8c169ab015adb0be35fac4992863)
-- **Technical baseline (the scaffold that produced this repo):** [Cinética BaseLine](https://gist.github.com/xXAreizaXx/8566c4410fe16fab5864abb72ae55e4a)
+The full project and baseline guides are mirrored inside this repo so they are always reachable:
+
+- **Project guide** (what we build and why) — [`docs/guides/project-guide.md`](./docs/guides/project-guide.md) · [upstream gist](https://gist.github.com/xXAreizaXx/16cb8c169ab015adb0be35fac4992863)
+- **Technical baseline** (the scaffold that produced this repo) — [`docs/guides/baseline.md`](./docs/guides/baseline.md) · [upstream gist](https://gist.github.com/xXAreizaXx/8566c4410fe16fab5864abb72ae55e4a)
+
+If a local copy and the upstream gist ever diverge, the gist is canonical.
 
 > _This product uses the API of TMDB but is not endorsed or certified by TMDB._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,263 @@
+# Contributing to Cineteca
+
+Thanks for contributing. This document is the single source of truth for **how** work lands in this repository: branches, commits, pull requests, the quality gate, and the rules the architecture expects you to follow.
+
+If you are looking for **what the project is** or **how to run it**, see the [README](./README.md). For depth on a specific topic — architecture, stack versions, the quality gate — see the [`docs/`](./docs) folder.
+
+---
+
+## Table of Contents
+
+1. [Branching model](#branching-model)
+2. [Commit and PR title convention](#commit-and-pr-title-convention)
+3. [Pull request process](#pull-request-process)
+4. [Quality gate](#quality-gate)
+5. [Architecture rules](#architecture-rules)
+6. [Local setup](#local-setup)
+7. [Reporting bugs and requesting features](#reporting-bugs-and-requesting-features)
+8. [References](#references)
+
+---
+
+## Branching model
+
+The repo uses a lightweight Git Flow with two long-lived branches and a handful of short-lived topic branches.
+
+### Long-lived branches
+
+| Branch  | Purpose                                                              | Receives merges from         | Protection                                                                 |
+| ------- | -------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------- |
+| `main`  | Production-ready code. Every commit on `main` is releasable.         | `release/*`, `hotfix/*`      | PR + 1 review + green CI + linear history + admins included                |
+| `develop` | Integration branch for the next release. Features accumulate here. | `feature/*`, `bugfix/*`, `release/*`, `hotfix/*` | PR + 1 review + green CI + linear history                                  |
+
+### Short-lived branches
+
+| Prefix       | Branched from | Merged back into               | Naming                                       |
+| ------------ | ------------- | ------------------------------ | -------------------------------------------- |
+| `feature/`   | `develop`     | `develop`                      | `feature/<scope>-<short-desc>`               |
+| `bugfix/`    | `develop`     | `develop`                      | `bugfix/<scope>-<short-desc>`                |
+| `chore/`     | `develop`     | `develop`                      | `chore/<scope>-<short-desc>`                 |
+| `release/`   | `develop`     | `main` **and** `develop`       | `release/vX.Y.Z`                             |
+| `hotfix/`    | `main`        | `main` **and** `develop`       | `hotfix/<scope>-<short-desc>`                |
+
+### Rules
+
+1. **Branch names are lowercase, kebab-case, and start with one of the allowed prefixes.** A PR from a branch that does not match is sent back.
+2. **`<scope>` is the affected layer or area.** Examples: `domain`, `infra`, `ui`, `docs`, `gate`, `cache`, `a11y`.
+3. **`<short-desc>` is 2–4 words, imperative mood, no issue number.** Examples: `add-money-type`, `wire-lists-detail`, `fix-rate-limit-retry`.
+4. **One concern per branch.** A branch that touches the domain layer and ships a UI redesign gets split.
+5. **Delete the branch after merge** (handled automatically by the repo setting).
+6. **Never commit directly to `main` or `develop`** — even admins use PRs.
+
+### Examples
+
+```text
+feature/domain-add-money-type
+feature/ui-movie-detail-expansion
+bugfix/cache-stale-trending-on-filter-change
+chore/docs-split-readme-and-contributing
+chore/ci-add-codecov-badge
+release/v0.1.0
+hotfix/env-validation-crash-on-empty-token
+```
+
+---
+
+## Commit and PR title convention
+
+We follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/). Because the repo uses **squash-merge only** (see below), the **PR title is the commit message** that ends up on `develop` or `main`. Getting the PR title right is the entire commit-message practice here.
+
+### Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Allowed types
+
+| Type       | Use when                                                     |
+| ---------- | ------------------------------------------------------------ |
+| `feat`     | A new user-visible feature                                   |
+| `fix`      | A bug fix                                                    |
+| `docs`     | Documentation-only changes                                   |
+| `refactor` | A code change that neither fixes a bug nor adds a feature   |
+| `perf`     | A code change that improves performance                      |
+| `test`     | Adding or correcting tests                                   |
+| `chore`    | Tooling, CI, dependencies, or other non-product changes     |
+| `build`    | Changes to the build system or external dependencies         |
+| `ci`       | Changes to CI configuration files and scripts                |
+| `style`    | Formatting only (no logic change)                            |
+| `revert`   | Reverts a previous commit                                    |
+
+### Allowed scopes
+
+Match the **layer or area** of the change. From the project architecture:
+
+- `domain` — pure TypeScript, entities, policies, formatters
+- `application` — use cases, ports
+- `infra` or `infrastructure` — HTTP, storage, API adapters
+- `ui` or `presentation` — React, routes, hooks, components
+- `config` — env, build, Vite, Tailwind
+- `gate` — quality gate scripts and CI
+- `a11y` — accessibility-only changes
+- `docs` — `docs/` folder and README
+- `deps` — dependency bumps
+- `release` — release prep
+
+### Subject rules
+
+- **Imperative mood, lowercase, no trailing period**: `add money type`, not `Added money type.` or `Adds money type.`
+- **Max 72 characters** total for the first line.
+- **Body wraps at 100 columns** and explains **why**, not what.
+- **Footer** for breaking changes (`BREAKING CHANGE: ...`) and issue references (`Closes #42`, `Refs #15`).
+
+### Examples
+
+```
+feat(domain): add Money type with Intl formatter
+
+Parse amounts from TMDB as integers in the smallest currency unit.
+Formatting is delegated to Intl.NumberFormat so locales work for free.
+
+Closes #21
+```
+
+```
+fix(cache): cancel in-flight trending query on filter change
+
+Without cancellation, switching genres mid-flight triggered a
+late-arriving response that overrode the new filter.
+
+Refs #35
+```
+
+```
+chore(docs): split README into README + CONTRIBUTING + docs/
+```
+
+```
+feat(infra)!: switch HTTP client from fetch to axios
+
+BREAKING CHANGE: replaces the native fetch wrapper. Existing
+interceptors must be ported to axios interceptors.
+```
+
+---
+
+## Pull request process
+
+1. **Branch off the right base.** `feature/*`, `bugfix/*`, and `chore/*` branch off `develop`. `hotfix/*` branches off `main`. `release/*` branches off `develop`.
+2. **Use the PR template.** It is enforced by `.github/pull_request_template.md`. PRs that arrive empty are sent back.
+3. **Keep PRs focused.** One concern per branch (see rule 4 above). Large refactors ship in multiple PRs.
+4. **Pass the gate locally before pushing.** Run `bash scripts/verify.sh --quick` for the inner loop, `bash scripts/verify.sh --full` before the push. See the [quality gate](#quality-gate) below.
+5. **Open the PR against the correct base.**
+   - `feature/*`, `bugfix/*`, `chore/*` → base is `develop`.
+   - `hotfix/*` → base is `main`, then a backport PR from `main` to `develop`.
+   - `release/*` → base is `main` (and a follow-up PR to `develop`).
+6. **Reference the issues it closes.** Use `Closes #N`, `Fixes #N`, or `Refs #N` in the PR body.
+7. **Request a review.** At least one approval is required to merge (see branch protection).
+8. **Merge with squash.** Only "Squash and merge" is allowed. The PR title becomes the squash commit message. The head branch is deleted automatically after merge.
+9. **Never use `--no-verify`.** A gate that can be skipped is not a gate.
+
+---
+
+## Quality gate
+
+Nothing reaches `main` or `develop` without the gate running green. The gate has two modes, both implemented in `scripts/verify.sh`:
+
+| Mode       | When                              | What it runs                                                                |
+| ---------- | --------------------------------- | --------------------------------------------------------------------------- |
+| `--quick`  | Pre-commit (Husky)                | format → lint → types                                                       |
+| `--full`   | Pre-push (Husky) and CI           | format → lint → types → tests (with coverage) → build → dependency check    |
+
+### Husky hooks
+
+- **`.husky/pre-commit`** runs `pnpm lint-staged` and `bash scripts/verify.sh --quick`.
+- **`.husky/pre-push`** runs `bash scripts/verify.sh --full`.
+
+### CI
+
+`.github/workflows/ci.yml` runs the **same** `verify.sh --full` script on every push to `main` and every pull request. Branch protection requires this `gate` check to pass before merge.
+
+### Time budget
+
+The quick gate targets **under 10 seconds**, the full gate **under 90 seconds**. If either grows beyond that, fix the cause; do not remove steps.
+
+### Reading a failure
+
+1. The output names the failing step (`[2/5] Linter — ESLint, cero advertencias`).
+2. The script exits non-zero on the first failed step.
+3. Re-run the failing step on its own (`pnpm lint`, `pnpm check-types`, `pnpm test`, `pnpm build`) to see the full output.
+4. For dependency deprecations, run `./scripts/check-versions.sh` to see the report.
+
+For the full reference, see [`docs/quality-gate.md`](./docs/quality-gate.md).
+
+---
+
+## Architecture rules
+
+The codebase follows Clean Architecture with a strict **dependency rule**: dependencies point inward, and the domain layer is pure TypeScript.
+
+| Layer              | May import                                | Must not import                              |
+| ------------------ | ----------------------------------------- | -------------------------------------------- |
+| `domain/`          | other `domain/` modules                   | React, Axios, TanStack Query, anything from `application/`, `infrastructure/`, `presentation/` |
+| `application/`     | `domain/`                                 | React, Axios, `presentation/`, `infrastructure/` |
+| `infrastructure/`  | `domain/`, `application/`, axios          | React, `presentation/`                       |
+| `presentation/`    | everything below it                       | —                                            |
+| `infrastructure/http/` | axios (only here)                    | anywhere else uses axios                      |
+
+The linter enforces this rule in `eslint.config.js` — see the `no-restricted-imports` blocks. A file in `domain/` that imports `react` fails lint, locally and in CI.
+
+For the full layer map, decision table, and conventions (states as discriminated unions, money as integers, three untrusted edges), see [`docs/architecture.md`](./docs/architecture.md).
+
+---
+
+## Local setup
+
+```bash
+# 1. Clone
+git clone https://github.com/Team-Centinela/Project-save-me-of-the-riwi.git
+cd Project-save-me-of-the-riwi
+
+# 2. Install dependencies
+corepack enable     # so pnpm version matches package.json
+pnpm install
+
+# 3. Configure the environment
+cp .env.example .env.local
+# Edit .env.local and set VITE_TMDB_READ_TOKEN to your TMDB Read Access Token.
+# The token is bundled into the client; use a practice account that can be
+# rotated in one minute from the TMDB API panel.
+
+# 4. Start the dev server
+pnpm dev            # http://localhost:5173
+
+# 5. Run the gate
+bash scripts/verify.sh --quick
+```
+
+Editor: install the **ESLint**, **Prettier**, and **Tailwind CSS IntelliSense** extensions. Turn on "format on save" pointing at Prettier.
+
+---
+
+## Reporting bugs and requesting features
+
+- **Bug?** Use the [Bug Report](../../issues/new?template=bug_report.yml) template.
+- **Feature?** Use the [Feature Request](../../issues/new?template=feature_request.yml) template.
+- **Refactor, tooling, or docs?** Use the [Chore / Tech Debt](../../issues/new?template=chore.yml) template.
+- **Security issue?** Email the maintainers privately — do not open a public issue.
+
+Before opening, search the existing issues to avoid duplicates. For bugs, reproduce on the latest `main` first.
+
+---
+
+## References
+
+- **Project guide (what we build and why):** [Cineteca project guide](https://gist.github.com/xXAreizaXx/16cb8c169ab015adb0be35fac4992863)
+- **Technical baseline (the scaffold that produced this repo):** [Cinética BaseLine](https://gist.github.com/xXAreizaXx/8566c4410fe16fab5864abb72ae55e4a)
+
+> _This product uses the API of TMDB but is not endorsed or certified by TMDB._

--- a/README.md
+++ b/README.md
@@ -167,5 +167,9 @@ For bugs and feature requests, please use the issue templates under [`.github/IS
 
 ## References
 
-- **Project guide (what we build and why):** [Cineteca project guide](https://gist.github.com/xXAreizaXx/16cb8c169ab015adb0be35fac4992863)
-- **Technical baseline (the scaffold that produced this repo):** [Cinética BaseLine](https://gist.github.com/xXAreizaXx/8566c4410fe16fab5864abb72ae55e4a)
+The full project and baseline guides are mirrored inside this repo so they are always reachable:
+
+- **Project guide** (what we build and why) — [`docs/guides/project-guide.md`](./docs/guides/project-guide.md) · [upstream gist](https://gist.github.com/xXAreizaXx/16cb8c169ab015adb0be35fac4992863)
+- **Technical baseline** (the scaffold that produced this repo) — [`docs/guides/baseline.md`](./docs/guides/baseline.md) · [upstream gist](https://gist.github.com/xXAreizaXx/8566c4410fe16fab5864abb72ae55e4a)
+
+If a local copy and the upstream gist diverge, the gist is canonical.

--- a/README.md
+++ b/README.md
@@ -1,179 +1,171 @@
 # Cineteca
 
-**Movie discovery and personal library web app · API client only (no backend)**
+> A web application for discovering movies and building a personal cinema library — explore the catalog, open a film's page, save what you want to watch, organize themed lists, and share exactly what you are seeing with a single link.
 
-A web application where users discover movies and build their own library — what they want to watch, what they've seen, and themed lists they can share via link.
-
-The catalog is powered by **TMDB**, a public REST API with fifteen years of history. This project does not build a server or database: it consumes the TMDB API and constructs the experience.
+Cineteca is a client-side web app that consumes [TMDB](https://www.themoviedb.org), a public REST API with over a decade of catalog history. There is no backend and no database to provision: the user's library lives in their own browser, validated against the same rigor as any network response.
 
 ---
 
-## Quick Start
+## Features
 
-### Prerequisites
-
-- Node.js 22+ (LTS)
-- pnpm 11.22.0
-- A TMDB API Read Access Token (see below)
-
-### Setup
-
-```bash
-# 1. Clone the repository
-git clone <repo-url>
-cd cineteca
-
-# 2. Install dependencies
-pnpm install
-
-# 3. Create your environment file
-cp .env.example .env.local
-# Add your TMDB Read Access Token to .env.local:
-# VITE_TMDB_READ_TOKEN=your_token_here
-
-# 4. Start development server
-pnpm dev
-```
-
-### Getting a TMDB Token
-
-1. Create a **practice account** at [themoviedb.org](https://www.themoviedb.org) (not a personal one)
-2. Go to *Settings → API* and request access
-3. Copy the **API Read Access Token** (the second credential)
-
-> **Note:** This token will be bundled into the client and is publicly visible. Use a practice account — it can be rotated in one minute from the same panel.
-
----
-
-## Scripts
-
-| Command | Description |
-|---|---|
-| `pnpm dev` | Start development server |
-| `pnpm build` | Production build |
-| `pnpm preview` | Preview production build |
-| `pnpm test` | Run tests with coverage |
-| `pnpm test:watch` | Run tests in watch mode |
-| `pnpm lint` | Run ESLint (zero warnings tolerated) |
-| `pnpm check-types` | Run TypeScript type checking |
-| `pnpm format` | Format code with Prettier |
-| `bash scripts/verify.sh --quick` | Run pre-commit quality gate |
-| `bash scripts/verify.sh --full` | Run full quality gate (pre-push / CI) |
-
----
-
-## Project Structure
-
-```
-src/
-├── domain/           # Pure TypeScript — entities, states, policies, validation schemas
-├── application/      # Use cases and ports (interfaces)
-├── infrastructure/   # API client, HTTP layer, storage adapters
-├── presentation/     # React components, routes, hooks, providers, copy
-├── config/           # Environment validation
-└── test/             # MSW server for testing
-```
-
-**Architecture rule (enforced by linter):** Dependencies point inward. The `domain/` layer knows nothing about React, HTTP libraries, or caching. If a domain file would need to install anything to work, it's in the wrong folder.
-
----
-
-## Key Design Decisions
-
-### Domain Modeling
-- **States as discriminated unions:** Movie state and rating reliability are modeled as tagged unions. Each branch carries exactly the data that belongs to it.
-- **Absences explicit in types:** No `0` or empty string from TMDB survives the boundary — all are translated to "no data" at the validation edge.
-- **Money as integers:** Budgets are stored in the smallest unit of the currency (cents, not dollars). Never use floating-point decimals for money.
-
-### Three Untrusted Edges
-Every edge is validated with the same rigor:
-1. **Network** — API responses are validated with Zod before use
-2. **Local Storage** — Read data is validated; corrupted data is discarded gracefully
-3. **URL** — Filter values written by hand in the URL cannot break the screen
-
-### Caching Strategy
-- Server state lives in **TanStack Query cache**
-- View state lives in the **URL** (filters, search)
-- User's library lives in **browser localStorage**
-
-### The Four States
-Every screen that shows data has four paths:
-- **Loading** — Skeleton with real card shape, not a spinner
-- **Error** — Plain language + retry button
-- **Initial Empty** — "Your cineteca is empty" with a link to explore
-- **Empty by Filter** — "No movies match these filters" with a button to clear them
-
----
-
-## Tech Stack
-
-| Layer | Tool | Version |
-|---|---|---|
-| Build | Vite | 8.2.1 |
-| Language | TypeScript (strict) | 6.0.3 |
-| UI | React | 19.2.8 |
-| Routing | React Router | 8.3.0 |
-| Styles | Tailwind CSS | 4.3.3 |
-| Data fetching | TanStack Query | 5.101.4 |
-| HTTP | Axios | 1.19.0 |
-| Validation | Zod | 4.4.3 |
-| Forms | React Hook Form | 7.85.0 |
-| Testing | Vitest + Testing Library + MSW | 4.1.11 / 16.3.2 / 2.15.0 |
-| Linting | ESLint + typescript-eslint + Prettier | 10.8.1 / 8.67.0 / 3.9.6 |
-
----
-
-## Quality Gate
-
-The gate runs on every commit (`--quick`) and before every push (`--full`):
-
-```
-format → lint → types → tests → build → dependency check
-```
-
-Zero warnings tolerated. A warning that nobody fixes multiplies until the linter stops reporting.
+- **Home** — what is trending this week, with one click into Explore.
+- **Explore** — filter the catalog by genre, year, minimum rating, minimum vote count, and sort order. Filters live in the URL, so reloading preserves the view and sharing the link reproduces it in another browser.
+- **Search** — free-text search with debounced requests; one keystroke does not equal one request.
+- **Movie detail** — full metadata, cast, and trailers loaded in a single expanded request. Shareable URL per film.
+- **My Cineteca** — your saved films and themed local lists. Save and remove with optimistic updates; the action reverts cleanly if storage fails.
+- **Four states, every screen** — every view that shows data handles loading, error, empty initial, and empty by filter. A filter mismatch is not a dead end; it offers a way out.
+- **Three edges, all validated** — network responses, localStorage reads, and URL parameters are each parsed through Zod schemas. A hand-typed nonsense filter does not break the screen.
+- **International formats** — dates, numbers, money, and durations use the browser's `Intl` APIs. The same film shows correctly in Spanish, English, and German.
+- **Keyboard-navigable end to end** — focus is always visible, route changes move focus to the new heading, and the document title updates so screen readers follow the navigation. The layout holds at 200% zoom.
 
 ---
 
 ## Screens
 
-| Screen | Description |
-|---|---|
-| **Home** | Trending movies of the week |
-| **Explore** | Filters (genre, year, rating, votes, sort) and results. **Filters live in the URL** — reload preserves the view, sharing reproduces it exactly |
-| **Search** | Free-text search with debounce |
-| **Movie Detail** | Full movie info with cast and trailers, shareable URL |
-| **My Cineteca** | Saved movies and local lists |
+| Route                          | Purpose                                                                                       |
+| ------------------------------ | --------------------------------------------------------------------------------------------- |
+| `/`                            | Trending this week                                                                            |
+| `/explore`                     | Filters + results; filters live in the URL                                                    |
+| `/search`                      | Free-text search with debounce                                                                 |
+| `/movie/:id`                   | Full detail page, shareable URL                                                                |
+| `/my-cineteca`                 | Saved films and local lists                                                                    |
+| `/my-cineteca/lists/:slug`     | A single local list, viewable and shareable                                                    |
+
+---
+
+## Quick start
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/Team-Centinela/Project-save-me-of-the-riwi.git
+cd Project-save-me-of-the-riwi
+
+# 2. Install dependencies
+corepack enable       # ensures pnpm version matches package.json
+pnpm install
+
+# 3. Configure the environment
+cp .env.example .env.local
+# Edit .env.local and set VITE_TMDB_READ_TOKEN to your TMDB Read Access Token.
+# The token is bundled into the client; use a practice account that can be
+# rotated in one minute from the TMDB API panel.
+
+# 4. Start the dev server
+pnpm dev              # http://localhost:5173
+```
+
+### Getting a TMDB token
+
+1. Create a **practice account** at [themoviedb.org](https://www.themoviedb.org) (not a personal one).
+2. Go to *Settings → API* and request access. Declare it as an educational, non-commercial project.
+3. Copy the **API Read Access Token** (the second credential).
+
+> The token is shipped inside the client bundle and is therefore public. That is acceptable here precisely because it is read-only, scoped to a practice account, and rotable in one minute from the same panel.
+
+---
+
+## Scripts
+
+| Command                              | What it does                                              |
+| ------------------------------------ | --------------------------------------------------------- |
+| `pnpm dev`                           | Start the dev server                                      |
+| `pnpm build`                         | Production build                                          |
+| `pnpm preview`                       | Preview the production build                              |
+| `pnpm test`                          | Run tests with coverage                                   |
+| `pnpm test:watch`                    | Run tests in watch mode                                   |
+| `pnpm lint`                          | Run ESLint (zero warnings tolerated)                      |
+| `pnpm check-types`                   | Run TypeScript type checking                              |
+| `pnpm format`                        | Format code with Prettier                                 |
+| `bash scripts/verify.sh --quick`     | Pre-commit gate: format, lint, types                      |
+| `bash scripts/verify.sh --full`      | Pre-push and CI gate: above plus tests, build, deps check |
+
+---
+
+## Architecture
+
+Cineteca follows Clean Architecture with a strict dependency rule. The **domain** layer is pure TypeScript and knows nothing about React, Axios, or the cache. **Application** defines the ports (`MovieRepository`, `LibraryStorage`, …). **Infrastructure** implements them (HTTP client, localStorage adapter). **Presentation** is the only place React lives.
+
+The rule is enforced by the linter, not by convention: importing `react` inside `src/domain/` fails the gate. If you are unsure where a file belongs, see [`docs/architecture.md`](./docs/architecture.md).
+
+```
+src/
+├── domain/           # Pure TypeScript — entities, states, policies, validation schemas, formatters
+├── application/      # Use cases and ports (interfaces)
+├── infrastructure/   # HTTP client, API modules, storage adapters
+├── presentation/     # React components, routes, hooks, providers, copy
+├── config/           # Environment validation
+└── test/             # MSW server for testing
+```
+
+---
+
+## Tech stack
+
+A versioned table lives in [`docs/tech-stack.md`](./docs/tech-stack.md). The summary:
+
+| Layer        | Tool                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| Build        | Vite                                                              |
+| Language     | TypeScript (strict)                                               |
+| UI           | React                                                             |
+| Routing      | React Router                                                      |
+| Styles       | Tailwind CSS                                                      |
+| Data         | TanStack Query                                                    |
+| HTTP         | Axios (one instance, one place)                                   |
+| Validation   | Zod                                                               |
+| Forms        | React Hook Form + Zod resolver                                    |
+| Virtualization | `@tanstack/react-virtual`                                       |
+| Testing      | Vitest + Testing Library + MSW + axe-core                         |
+| Quality      | ESLint + typescript-eslint + Prettier                             |
+| Gate         | Husky + lint-staged + `verify.sh`                                 |
+| Package mgr  | pnpm                                                              |
+
+The intentional exclusions are documented in [`docs/tech-stack.md`](./docs/tech-stack.md): no Redux, no Zustand, no Jotai. Server state lives in the Query cache, view state lives in the URL, the library lives in its own validated module.
+
+---
+
+## Quality gate
+
+The gate is the same script locally and in CI: `scripts/verify.sh`. Its steps are
+
+```
+format → lint → types → tests → build → dependency check
+```
+
+A pull request cannot land without the `gate` CI check green. Branch protection on `main` and `develop` enforces this. The full reference — modes, hooks, time budget, how to read a failure — is in [`docs/quality-gate.md`](./docs/quality-gate.md).
 
 ---
 
 ## Accessibility
 
-- All interactive elements are keyboard reachable
-- Focus is always visible
-- Movie cards are a single link with accessible name: "The Godfather, 1972, 8.7 out of 10"
-- Document title and focus move on route change
-- Zoom at 200% without breakage or horizontal scroll
-- Rating state is never communicated by color alone
+- Every interactive element is keyboard reachable; focus is always visible.
+- A movie card is a single link with an accessible name like `"The Godfather, 1972, 8.7 out of 10"`.
+- On route change, the document title updates and focus moves to the new heading.
+- Form errors are announced to assistive tech, not just painted in red, and focus jumps to the first invalid field.
+- The layout holds at 200% zoom with no horizontal scroll.
+- Status (released / unreleased / unknown) is never communicated by color alone.
 
 ---
 
-## TMDB Attribution
+## TMDB attribution
 
 This product uses the TMDB API but is not endorsed or certified by TMDB.
 
-> *"This product uses the API of TMDB but is not endorsed or certified by TMDB."*
+> _"This product uses the API of TMDB but is not endorsed or certified by TMDB."_
 
-Required by TMDB's terms of use. Display in footer from day one.
+This attribution is required by TMDB's terms of use and is rendered in the application footer.
 
 ---
 
-## Out of Scope
+## Contributing
 
-These are deliberate exclusions:
-- User accounts, login, roles, permissions (library lives in browser)
-- Backend or proxy to hide credentials
-- TV series as dedicated sections
-- Offline mode with service worker
+To contribute, read [`CONTRIBUTING.md`](./CONTRIBUTING.md) for branching, commit messages, the PR process, the quality gate, and the architecture rules.
 
-If you finish the base scope, go for **depth over breadth**: more states covered, better accessibility, more edge cases tested.
+For bugs and feature requests, please use the issue templates under [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE).
+
+---
+
+## References
+
+- **Project guide (what we build and why):** [Cineteca project guide](https://gist.github.com/xXAreizaXx/16cb8c169ab015adb0be35fac4992863)
+- **Technical baseline (the scaffold that produced this repo):** [Cinética BaseLine](https://gist.github.com/xXAreizaXx/8566c4410fe16fab5864abb72ae55e4a)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,165 @@
+# Architecture
+
+Cineteca follows **Clean Architecture** with a strict **dependency rule**: dependencies point inward, and the innermost layer is pure TypeScript. The rule is enforced by the linter — see `eslint.config.js` — not by convention. A file that violates it fails `pnpm lint`, locally and in CI.
+
+This document is a reference. For the contributor-facing summary, see the [Architecture rules](../../CONTRIBUTING.md#architecture-rules) section of `CONTRIBUTING.md`.
+
+---
+
+## Layer map
+
+```
+src/
+├── domain/           pure TypeScript — entities, states, policies, schemas, formatters
+├── application/      use cases and ports (interfaces)
+├── infrastructure/   HTTP client, API modules, storage adapters
+├── presentation/     React components, routes, hooks, providers, copy
+├── config/           environment validation
+└── test/             MSW server for testing
+```
+
+| Layer            | Responsibility                                                                  | Allowed imports                                          | Forbidden imports                                                |
+| ---------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| `domain/`        | Business entities, rules, and formatters                                        | other `domain/` modules                                  | React, Axios, TanStack Query, anything from `application/`, `infrastructure/`, `presentation/` |
+| `application/`   | Use cases; ports (interfaces) that the infrastructure must implement            | `domain/`                                                | React, Axios, anything from `presentation/` or `infrastructure/` |
+| `infrastructure/` | Implementations of the ports: HTTP calls with validation, storage adapter      | `domain/`, `application/`, axios (only in `http/`)       | React, anything from `presentation/`                             |
+| `presentation/`  | React UI, routes, hooks, providers, copy                                         | everything below it                                      | —                                                                |
+| `infrastructure/http/` | The single place that imports `axios`                                       | axios                                                     | anywhere else that imports axios                                  |
+
+The **single-source rule for the HTTP library** is the most concrete. `axios` is allowed in exactly one directory tree, `src/infrastructure/http/**`. The linter rejects the import anywhere else. This keeps the transport replaceable and makes the network edge easy to find.
+
+---
+
+## Where does this file go?
+
+The question that comes up every day is "where does this file live?". Use this table:
+
+| What you are writing                                                   | Goes in                          |
+| ---------------------------------------------------------------------- | -------------------------------- |
+| A business rule, entity, state, formatter, schema, policy              | `domain/`                        |
+| An interface for "something that fetches X" or "something that stores Y" | `application/ports/`           |
+| A network call with its validation                                     | `infrastructure/api/`            |
+| The HTTP client and its interceptors                                   | `infrastructure/http/`           |
+| The browser storage adapter                                            | `infrastructure/storage/`        |
+| A React component, route, hook, provider                               | `presentation/`                  |
+| A user-visible string                                                  | `presentation/copy/`             |
+| Environment validation                                                 | `config/`                        |
+
+**Rule of thumb:** if a file in `domain/` would need to install something to work, it is in the wrong folder.
+
+---
+
+## The dependency rule, enforced
+
+`eslint.config.js` contains three `no-restricted-imports` blocks:
+
+1. Files under `src/domain/**/*.ts` cannot import `react`, `react-*`, `axios`, `@tanstack/*`, `react-hook-form`, or anything from `@/presentation/*`, `@/infrastructure/*`, `@/application/*`.
+2. Files under `src/application/**/*.ts` cannot import from `@/presentation/*`, `@/infrastructure/*`, `axios`, or `react*`.
+3. Any file under `src/**/*.{ts,tsx}` except `src/infrastructure/http/**` cannot import `axios`.
+
+Try it:
+
+```bash
+mkdir -p src/domain/shared
+echo "import { useState } from 'react'; export const x = useState;" > src/domain/shared/bad.ts
+pnpm lint    # must FAIL
+rm src/domain/shared/bad.ts
+pnpm lint    # must pass
+```
+
+A rule that only lives in a diagram breaks the first time someone is in a hurry. A rule that lives in the linter and the CI does not.
+
+---
+
+## Domain modeling conventions
+
+These are the rules that govern the `domain/` layer. They are not stylistic preferences; they are the contract that makes the type system carry the truth instead of the screens.
+
+### States as discriminated unions
+
+States are modeled as tagged unions. Each branch carries exactly the data that belongs to it.
+
+```ts
+type MovieState =
+  | { kind: 'released'; releaseDate: Date }
+  | { kind: 'unreleased'; expectedReleaseDate: Date }
+  | { kind: 'unknown' };
+
+type RatingReliability =
+  | { kind: 'consolidated'; votes: number; average: number }
+  | { kind: 'preliminary'; votes: number; average: number }
+  | { kind: 'absent' };
+```
+
+A `switch` over a tagged union with a default that the compiler considers unreachable forces every variant to be handled. Add a new variant, the compiler tells you which screens forgot it.
+
+### Absences are explicit in the type
+
+No `0` and no empty string from TMDB survives the validation edge. All of them are translated to "no data" at the boundary.
+
+```ts
+type NoData = { kind: 'absent' } | { kind: 'present'; value: string };
+```
+
+Inside the domain, the type says whether the data is there. Screens are forced to handle absence.
+
+### Money as integers
+
+A budget is not a floating-point number — that arithmetic loses cents. A budget is an integer in the smallest unit of the currency.
+
+```ts
+type Money = { amount: number; currency: string }; // amount in the smallest unit
+```
+
+Three rules to internalize:
+
+1. **Never a floating-point decimal for money.** Integers in the smallest unit, always.
+2. **Currency and locale are different things.** The currency is data (TMDB reports USD); the format is a viewer preference. `$63,000,000` in `en-US` and `63.000.000 $` in `de-DE` are both correct.
+3. **Formatting is delegated.** Use `Intl.NumberFormat` for money, `Intl.DateTimeFormat` for dates, and `Intl.PluralRules` for plurals. A thousand separator written with `replace` is a bug waiting for a new locale.
+
+---
+
+## The three untrusted edges
+
+Every edge that crosses a trust boundary is validated with the same rigor.
+
+1. **Network** — API responses are validated with Zod before use. Breaking a field in an MSW handler must produce a localized, clear error — never a silent wrong value.
+2. **Local storage** — data is validated on read with the same schema that produced it on write. Corrupted or invented data is discarded gracefully.
+3. **URL** — filter values written by hand in the URL cannot break the screen. They are parsed with Zod and fall back to defaults on failure.
+
+The URL edge is the one most apps forget. Cineteca treats it like the other two.
+
+---
+
+## The four states of every screen
+
+Any screen that shows data has four paths:
+
+| State            | What it shows                                                              |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Loading**      | A skeleton with the real shape of the upcoming content, not a centered spinner |
+| **Error**        | Plain language and a retry button. "We could not load the movies," not "Error 500" |
+| **Empty initial** | "Your Cineteca is empty," with a link to explore                          |
+| **Empty by filter** | "No movies match these filters," with a button to clear them            |
+
+A filter mismatch is not a dead end — it is a screen with a single action that recovers it.
+
+---
+
+## Caching and state ownership
+
+- **Server state** lives in the TanStack Query cache. It is the only place network data lives.
+- **View state** (filters, search query, current page) lives in the URL. Reload preserves it; sharing reproduces it.
+- **User library** lives in `localStorage`, behind a validated adapter.
+
+Between these three places there is almost nothing left, which is why Cineteca does not need a global state store.
+
+---
+
+## Copy is code
+
+Every user-visible string lives in `src/presentation/copy/`. No component writes a literal string inline. The reasons are the same as for state:
+
+- Translation is a single-file concern.
+- Consistency (e.g. always calling it "Cineteca", never "your library") is enforceable.
+- Tests can assert on the copy module without mounting React.

--- a/docs/guides/baseline.md
+++ b/docs/guides/baseline.md
@@ -1,0 +1,746 @@
+> **Local mirror.** This is a copy of the upstream Cinética BaseLine guide for self-contained reference. The canonical, most up-to-date version lives at <https://gist.github.com/xXAreizaXx/8566c4410fe16fab5864abb72ae55e4a>. If the two ever diverge, the gist wins.
+
+---
+
+# Cineteca — Línea base
+
+**Del repositorio vacío al andamio en verde · sin una sola funcionalidad**
+
+> **Qué es y qué no es.** Esta guía termina cuando el proyecto arranca, pasa el gate de calidad y **todavía no hace nada**. No hay dominio, no hay consumo de la API, no hay pantallas: eso pertenece a la guía del proyecto y empieza donde esta acaba. Aquí solo hay dependencias, archivos base, estilos, configuración y comandos.
+>
+> Se hace **una vez, entre todos, en la misma sesión**. Es media jornada. Que cada persona monte su propia línea base es la forma más rápida de tener cinco proyectos distintos el miércoles.
+
+---
+
+## Lo que van a tener al terminar
+
+- [ ] `pnpm dev` sirve una pantalla vacía con el tema aplicado y cero errores en consola
+- [ ] `pnpm check-types` en verde con TypeScript en modo severo
+- [ ] `pnpm lint` en verde, con cero advertencias toleradas
+- [ ] `pnpm test` en verde con una prueba de humo
+- [ ] `bash scripts/verify.sh --full` en verde
+- [ ] Un commit rechazado a propósito, para comprobar que el gate existe de verdad
+- [ ] La estructura de carpetas creada y vacía, esperando el primer archivo del dominio
+- [ ] La credencial de TMDB en `.env.local`, validada al arrancar, y **fuera** del repositorio
+
+---
+
+## Tres reglas antes de empezar
+
+**El orden importa.** Cada paso asume el anterior. Saltarse el linter para "avanzar más rápido" significa reescribir archivos el jueves.
+
+**Cada paso termina en un checkpoint.** Un comando que corren o algo que miran en pantalla. Si no pasa, no avanzan: en este stack los errores no se acumulan, se multiplican.
+
+**Las versiones no se fijan de memoria.** Las de este documento se verificaron contra el registry de npm el **19 de agosto de 2026**. Una tabla de versiones es una foto; el registry es la verdad. Verifíquenlas antes de instalar y usen siempre la última estable que el resto del ecosistema soporte — nunca versiones de prueba (`beta`, `rc`, `canary`, `next`).
+
+Todo comando se corre desde la raíz del proyecto salvo aviso.
+
+---
+
+## Paso 1 · Prerrequisitos
+
+```bash
+node -v            # el LTS activo; si no, instálenlo desde nodejs.org
+corepack enable    # deja que el repositorio fije su gestor de paquetes
+pnpm -v            # 11.22.0 al momento de escribir esto
+git --version
+```
+
+`corepack` existe para que la versión de pnpm la mande el `package.json` y no la máquina de cada uno. Sin eso, un lockfile generado con otra versión produce el clásico "en mi máquina funciona".
+
+En el editor, tres extensiones: **ESLint**, **Prettier** y **Tailwind CSS IntelliSense**, con *formatear al guardar* apuntando a Prettier. Que el editor y el gate digan lo mismo.
+
+---
+
+## Paso 2 · La credencial de TMDB
+
+1. Crear una cuenta **de práctica** en `themoviedb.org` (no la personal de nadie).
+2. Entrar a *Settings → API* y solicitar acceso. Piden un formulario de uso: declaren que es un proyecto educativo sin fines comerciales.
+3. Al aprobarse hay dos credenciales. Copien la segunda, el **API Read Access Token**: sirve igual para las dos versiones de la API, así que hay un solo mecanismo en todo el código en vez de dos.
+
+Checkpoint, antes de seguir:
+
+```bash
+export TMDB_TOKEN="eyJ...tu-read-access-token"
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer $TMDB_TOKEN" \
+  https://api.themoviedb.org/3/configuration
+# Se espera: 200
+```
+
+Si sale `401`, el token está mal copiado — suelen colarse saltos de línea al pegar.
+
+> **Asúmanlo desde ahora:** esta credencial va a acabar dentro del bundle y cualquiera puede leerla. Es de solo lectura, de una cuenta de práctica y rotable en un minuto desde el mismo panel. Eso la hace aceptable **aquí y solo aquí**.
+
+---
+
+## Paso 3 · Crear el proyecto
+
+```bash
+pnpm create vite@latest cineteca --template react-ts
+cd cineteca
+pnpm install
+pnpm dev     # http://localhost:5173 debe cargar la plantilla
+```
+
+Limpien el andamio ahora, porque si no sobrevive hasta producción:
+
+```bash
+rm -f src/App.css src/assets/react.svg public/vite.svg
+```
+
+Dejen `src/App.tsx` con un `<h1>Cineteca</h1>` y nada más. `src/index.css` se vacía: en el paso 6 se convierte en el archivo de tokens del tema.
+
+En `index.html`, dos detalles que después se olvidan: `lang="es"` en la etiqueta `html` y un `<title>` de verdad.
+
+Fijen el toolchain y los scripts en `package.json`:
+
+```jsonc
+{
+  "name": "cineteca",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.22.0",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --max-warnings 0",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "prepare": "husky"
+  }
+}
+```
+
+`--max-warnings 0` es una decisión de fondo, no un detalle: una advertencia que nadie arregla se multiplica hasta que el linter deja de informar. Aquí **una advertencia es un fallo**.
+
+```bash
+git init && git add -A && git commit -m "chore: scaffold vite + react + ts"
+```
+
+**Checkpoint:** `pnpm dev` sirve la página con el título y cero errores en consola.
+
+---
+
+## Paso 4 · TypeScript en modo severo
+
+```bash
+pnpm add -D typescript@6.0.3
+```
+
+**Por qué no la última (7.0.2).** `typescript-eslint@8.67.0` declara en sus dependencias de pares `typescript >=4.8.4 <6.1.0`. Con TypeScript 7, el linter con reglas de tipo deja de funcionar — y ese linter es quien va a imponer la arquitectura en el paso 7. Renunciar al linter para tener el compilador nuevo es un mal negocio. Dejen la nota para acordarse:
+
+```
+// TODO(upgrade): subir a TypeScript 7 cuando typescript-eslint admita >=7 en peerDependencies
+```
+
+En `tsconfig.app.json`, dentro de `compilerOptions`:
+
+```jsonc
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
+  }
+}
+```
+
+| Bandera | Qué evita |
+|---|---|
+| `noUncheckedIndexedAccess` | Acceder al primer elemento de una lista vacía. Con la bandera, ese acceso es "el elemento **o** indefinido" y el compilador obliga a decidir qué pasa cuando no hay nada. La que atrapa más bugs reales en este proyecto |
+| `exactOptionalPropertyTypes` | Que una propiedad opcional acepte el valor "indefinido" explícito. Al construir filtros esa diferencia decide si una clave de caché cambia o no |
+| `noFallthroughCasesInSwitch` | Un caso sin corte que se cuela al siguiente |
+| `verbatimModuleSyntax` | Imports de tipos que sobreviven al build; obliga a marcarlos como tipos |
+| `noUnusedLocals` / `noUnusedParameters` | Código muerto acumulándose durante una semana de prisa |
+
+TypeScript resuelve el alias `@/`, pero el empaquetador no se enteraría. Hay que decírselo también a Vite:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({ plugins: [react(), tsconfigPaths()] });
+```
+
+**Checkpoint:** `pnpm check-types` en verde. Comprueben que las banderas están vivas: declaren una lista vacía, accedan a su primer elemento y confirmen que el compilador se queja. Bórrenlo después.
+
+---
+
+## Paso 5 · Dependencias
+
+### 5.1 Primero el verificador de versiones
+
+```bash
+mkdir -p scripts
+```
+
+```bash
+# scripts/check-versions.sh
+#!/usr/bin/env bash
+# Compara lo instalado contra la última estable del registry y detecta paquetes
+# deprecados. Con --gate sale con error si hay alguno (lo usa verify.sh).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+GATE="${1:-}"
+FAILED=0
+deps=$(node -p "const p=require('./package.json');Object.keys({...p.dependencies,...p.devDependencies}).join('\n')")
+printf '%-38s %-14s %-14s %s\n' PAQUETE INSTALADA ÚLTIMA ESTADO
+while read -r dep; do
+  [ -z "$dep" ] && continue
+  installed=$(node -p "try{require('$dep/package.json').version}catch(e){'?'}" 2>/dev/null || echo '?')
+  latest=$(pnpm view "$dep" version 2>/dev/null || echo '?')
+  deprecated=$(pnpm view "$dep" deprecated 2>/dev/null || true)
+  status="ok"
+  [ -n "$deprecated" ] && { status="DEPRECADO"; FAILED=1; }
+  [ "$installed" != "$latest" ] && [ "$status" = "ok" ] && status="hay $latest"
+  printf '%-38s %-14s %-14s %s\n' "$dep" "$installed" "$latest" "$status"
+done <<< "$deps"
+if [ "$GATE" = "--gate" ] && [ "$FAILED" -ne 0 ]; then
+  echo "✖ Hay dependencias deprecadas. Reemplácenlas por su sucesor documentado."; exit 1
+fi
+```
+
+```bash
+chmod +x scripts/check-versions.sh
+```
+
+### 5.2 Bloque A · Runtime
+
+```bash
+pnpm add react-router@8.3.0 @tanstack/react-query@5.101.4 axios@1.19.0 zod@4.4.3 \
+  react-hook-form@7.85.0 @hookform/resolvers@5.9.1 @tanstack/react-virtual@3.14.10 \
+  lucide-react@1.33.0 react-error-boundary@6.1.3 \
+  clsx@2.1.1 tailwind-merge@3.6.0 class-variance-authority@0.7.1
+```
+
+Dos avisos que cuestan una hora si se descubren solos:
+
+- **React Router 8 se importa desde `react-router`**, no desde `react-router-dom` — ese paquete se quedó en la línea 7. Si encuentran un tutorial con `react-router-dom`, es de la versión anterior.
+- **`@hookform/resolvers` tiene que ser 5 o mayor** para hablar con Zod 4. Con la versión 3 y Zod 4, el conector falla con un error de tipos indescifrable.
+
+### 5.3 Bloque B · Estilos
+
+```bash
+pnpm add -D tailwindcss@4.3.3 @tailwindcss/vite@4.3.3
+```
+
+### 5.4 Bloque C · Pruebas
+
+```bash
+pnpm add -D vitest@4.1.11 @vitest/coverage-v8@4.1.11 jsdom@30.0.1 \
+  @testing-library/react@16.3.2 @testing-library/user-event@14.6.5 \
+  @testing-library/jest-dom@7.0.1 msw@2.15.0 axe-core@4.13.0 \
+  vite-tsconfig-paths@6.1.1
+```
+
+`axe-core` va directo, sin envoltorio: los paquetes que lo envuelven para Vitest están sin mantenimiento, y el envoltorio son doce líneas propias. **La dependencia más pequeña que resuelve el problema.**
+
+### 5.5 Bloque D · Calidad
+
+```bash
+pnpm add -D eslint@10.8.1 typescript-eslint@8.67.0 prettier@3.9.6 \
+  eslint-config-prettier@10.1.8 eslint-plugin-react-hooks@7.1.1 \
+  eslint-plugin-jsx-a11y@6.10.2 @tanstack/eslint-plugin-query@5.101.4 \
+  globals@17.11.0 husky@9.1.7 lint-staged@17.3.0 \
+  @tanstack/react-query-devtools@5.101.4
+```
+
+`eslint-plugin-jsx-a11y` no es decoración: es el único miembro del equipo que se acuerda de la accesibilidad a las once de la noche del día 6.
+
+**Checkpoint:**
+
+```bash
+./scripts/check-versions.sh    # cero deprecados
+pnpm check-types
+git add -A && git commit -m "chore: add project dependencies"
+```
+
+---
+
+## Paso 6 · Tailwind y los tokens del tema
+
+Tailwind 4 es **CSS-first**: no hay archivo de configuración, no hay lista de rutas que mantener, y los tokens viven en el CSS.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({ plugins: [react(), tailwindcss(), tsconfigPaths()] });
+```
+
+```css
+/* src/index.css — el contrato de diseño del proyecto */
+@import "tailwindcss";
+
+@theme {
+  /* Superficies y texto: nombres semánticos, jamás descriptivos */
+  --color-surface:        oklch(0.16 0.02 265);
+  --color-surface-raised: oklch(0.21 0.02 265);
+  --color-ink:            oklch(0.97 0.01 265);
+  --color-ink-muted:      oklch(0.72 0.02 265);
+  --color-brand:          oklch(0.72 0.17 152);
+  --color-danger:         oklch(0.63 0.20 25);
+
+  /* Estados del catálogo: si mañana cambia el ámbar, se toca UNA línea */
+  --color-status-released:   oklch(0.72 0.17 152);
+  --color-status-unreleased: oklch(0.80 0.15 85);
+  --color-status-unknown:    oklch(0.60 0.02 265);
+
+  /* La valoración tiene su propio nivel tipográfico */
+  --text-rating: 1.375rem;
+  --text-rating--line-height: 1.1;
+
+  /* Área táctil mínima con nombre, para que nadie escriba 44px suelto */
+  --spacing-touch: 2.75rem;
+  --radius-card:   0.75rem;
+  --aspect-poster: 2 / 3;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+Tres reglas que nacen aquí y rigen todo el proyecto:
+
+- **Los valores literales de color viven solo en `@theme`.** Un color escrito a mano dentro de un componente es una fuga del contrato de diseño.
+- **Los nombres son semánticos.** `status-unreleased` comunica intención; `amber-500` solo comunica color.
+- **Las clases se fusionan con una utilidad, nunca concatenando cadenas.** Creen un archivo `src/presentation/lib/cn.ts` que combine `clsx` con `tailwind-merge` y expórtenlo como `cn`: son dos líneas y evitan el bug silencioso más común del stack — dos paddings en la misma cadena, gana uno de los dos y nadie sabe cuál.
+
+Asegúrense de que `src/main.tsx` importa `./index.css`.
+
+**Checkpoint:** un elemento con `bg-surface text-ink min-h-touch rounded-card` se ve con los colores del tema. Si sale sin estilo, falta el plugin en `vite.config.ts` o el `@import` en el CSS.
+
+---
+
+## Paso 7 · ESLint y Prettier
+
+Este archivo es el que convierte "Clean Architecture" de un diagrama en una regla ejecutable. Va en **JavaScript** (`eslint.config.js`): la configuración en TypeScript necesita un cargador extra y no vale la pena en la línea base.
+
+```js
+// eslint.config.js
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import query from '@tanstack/eslint-plugin-query';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  { ignores: ['dist', 'coverage'] },
+
+  js.configs.recommended,
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  reactHooks.configs['recommended-latest'],
+  jsxA11y.flatConfigs.recommended,
+  query.configs['flat/recommended'],
+
+  {
+    languageOptions: {
+      globals: globals.browser,
+      parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+    },
+  },
+
+  // ── LA REGLA DE DEPENDENCIA ───────────────────────────────────────────
+  // El dominio es TypeScript puro: no conoce React, ni la librería HTTP, ni
+  // la caché, ni las capas de fuera. Eso es lo que lo vuelve testeable sin
+  // un solo doble de prueba.
+  {
+    files: ['src/domain/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['react', 'react-*', 'axios', '@tanstack/*', 'react-hook-form'],
+            message: 'El dominio no depende de frameworks.' },
+          { group: ['@/presentation/*', '@/infrastructure/*', '@/application/*'],
+            message: 'Las dependencias apuntan hacia dentro.' },
+        ],
+      }],
+    },
+  },
+  {
+    files: ['src/application/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@/presentation/*', '@/infrastructure/*'],
+            message: 'La aplicación define interfaces; la infraestructura las implementa, no al revés.' },
+          { group: ['axios', 'react', 'react-*'],
+            message: 'La aplicación no sabe cómo viajan los datos.' },
+        ],
+      }],
+    },
+  },
+  // La librería HTTP existe en UN solo directorio. Si aparece en otro, el
+  // transporte dejó de ser sustituible.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/infrastructure/http/**'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        paths: [{ name: 'axios', message: 'Solo src/infrastructure/http puede importar axios.' }],
+      }],
+    },
+  },
+
+  { files: ['**/*.spec.{ts,tsx}'], rules: { '@typescript-eslint/no-non-null-assertion': 'off' } },
+  prettier,   // último siempre: apaga lo que Prettier decide
+);
+```
+
+```json
+// .prettierrc.json
+{ "singleQuote": true, "semi": true, "printWidth": 100, "trailingComma": "all" }
+```
+
+### Checkpoint · La demostración de 60 segundos
+
+```bash
+mkdir -p src/domain/shared
+echo "import { useState } from 'react'; export const x = useState;" > src/domain/shared/bad.ts
+pnpm lint    # debe FALLAR: "El dominio no depende de frameworks"
+rm src/domain/shared/bad.ts
+pnpm lint    # debe pasar
+```
+
+Háganlo de verdad, todos, mirando la pantalla. Una regla de arquitectura que solo vive en un diagrama se rompe el jueves; una que vive en el linter y en el CI, no.
+
+---
+
+## Paso 8 · Vitest, Testing Library y MSW
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.spec.{ts,tsx}', 'src/main.tsx', 'src/**/*.d.ts', 'src/test/**'],
+      // Los umbrales se activan en el paso del dominio, cuando ya haya código
+      // propio que cubrir. Encenderlos con el andamio vacío solo enseña a
+      // negociar con el gate.
+      // thresholds: {
+      //   lines: 80, functions: 80, branches: 80, statements: 80,
+      //   'src/domain/**/*.ts': { lines: 100, functions: 100, branches: 100, statements: 100 },
+      // },
+    },
+  },
+});
+```
+
+```ts
+// vitest.setup.ts
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
+import { server } from './src/test/msw/server';
+
+// onUnhandledRequest: 'error' es la línea que hace útil a MSW: una petición que
+// nadie simuló revienta el test en vez de irse a la red de verdad.
+beforeAll(() => { server.listen({ onUnhandledRequest: 'error' }); });
+afterEach(() => { server.resetHandlers(); cleanup(); });
+afterAll(() => { server.close(); });
+
+// jsdom no implementa ninguno de los dos, y el tema y el virtualizador los piden.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false, media: query, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {} unobserve() {} disconnect() {}
+} as unknown as typeof ResizeObserver;
+```
+
+```ts
+// src/test/msw/server.ts
+import { setupServer } from 'msw/node';
+
+// Arranca sin simulaciones a propósito: cada una se añade con la funcionalidad
+// que la necesita, con respuestas reales de la API como base.
+export const server = setupServer();
+```
+
+**Checkpoint:** escriban una única prueba de humo que monte el esqueleto de la app y compruebe que aparece el encabezado. `pnpm test` en verde.
+
+---
+
+## Paso 9 · La estructura de carpetas
+
+```bash
+mkdir -p \
+  src/domain/shared \
+  src/application/ports \
+  src/infrastructure/{http,api,storage} \
+  src/presentation/{routes,components/{ui,feature},hooks,providers,copy,lib} \
+  src/config src/test/msw
+```
+
+Las carpetas quedan vacías. La duda real de la semana no es qué carpetas hay, sino **dónde va este archivo**:
+
+| Lo que están escribiendo | Va en |
+|---|---|
+| Una regla de negocio, un estado, un formateador | `domain/` |
+| La interfaz de "algo que trae datos" o "algo que los guarda" | `application/ports/` |
+| La llamada a la red con su validación | `infrastructure/api/` |
+| El cliente HTTP y sus interceptores | `infrastructure/http/` |
+| El acceso al almacenamiento del navegador | `infrastructure/storage/` |
+| Un hook de datos, un componente, una ruta | `presentation/` |
+| Un texto visible por el usuario | `presentation/copy/` |
+
+**Regla de bolsillo:** si un archivo de `domain/` necesitara instalar algo para funcionar, está en la carpeta equivocada.
+
+---
+
+## Paso 10 · La configuración, validada
+
+El entorno es un borde no confiable como cualquier otro: si falta una variable, la app tiene que morir **al arrancar**, con un mensaje claro, y no tres pantallas después con un error de autorización inexplicable.
+
+```ts
+// src/config/env.ts
+import { z } from 'zod';
+
+const envSchema = z.object({
+  VITE_TMDB_READ_TOKEN: z.string().min(40, 'Falta el API Read Access Token de TMDB'),
+  VITE_TMDB_API_BASE: z.string().url().default('https://api.themoviedb.org'),
+  VITE_TMDB_IMAGE_BASE: z.string().url().default('https://image.tmdb.org/t/p'),
+});
+
+const parsed = envSchema.safeParse(import.meta.env);
+
+if (!parsed.success) {
+  throw new Error(`Configuración inválida:\n${z.prettifyError(parsed.error)}`);
+}
+
+export const env = parsed.data;
+```
+
+```bash
+# .env.example   (SÍ se commitea)
+VITE_TMDB_READ_TOKEN=pon-aqui-tu-api-read-access-token
+```
+
+```bash
+# .env.local     (NUNCA se commitea)
+VITE_TMDB_READ_TOKEN=eyJ...
+```
+
+```bash
+printf '\n.env.local\n.env*.local\ncoverage\n' >> .gitignore
+```
+
+**El prefijo `VITE_` es una advertencia, no burocracia:** Vite solo expone al cliente las variables con ese prefijo, precisamente para que nadie filtre un secreto por accidente. Que su credencial lo lleve significa que es pública.
+
+**Checkpoint:** borren la variable de `.env.local`, corran `pnpm dev` y confirmen que la app muere con el mensaje en español. Devuélvanla.
+
+---
+
+## Paso 11 · El esqueleto de la aplicación
+
+Cuatro archivos base, sin ninguna funcionalidad dentro:
+
+| Archivo | Qué contiene |
+|---|---|
+| `src/main.tsx` | El punto de entrada: importa el CSS, monta React en modo estricto y envuelve la app en los proveedores |
+| `src/presentation/providers/app-providers.tsx` | El proveedor de la caché de datos y el límite de errores de render. Las opciones por defecto de la caché **se dejan para el paso de la capa de datos**: aquí solo se monta |
+| `src/presentation/routes/router.tsx` | El enrutador con una ruta raíz, un contenedor común y una ruta de "no encontrado". Vacías |
+| `src/presentation/routes/root-layout.tsx` | La cabecera, el pie con la atribución a TMDB y el hueco donde se pintarán las páginas |
+
+Tres decisiones que se toman ahora y no se discuten después:
+
+- **React en modo estricto**, desde el principio. Descubrir en el día 5 que un efecto se ejecuta dos veces es un mal día; descubrirlo hoy no cuesta nada.
+- **Un límite de errores de render** desde el primer commit. Un error suelto no puede dejar la pantalla en blanco, y en desarrollo el mensaje ahorra tiempo.
+- **La atribución a TMDB en el pie, ya.** Los términos de uso de la API exigen mostrar el logo y la frase correspondiente. Es la licencia bajo la que consumen el servicio, no un detalle estético — y puesta el primer día, no se olvida el último.
+
+Añadan también las devtools de la caché, condicionadas a que la app corra en desarrollo. Ver la caché en vivo vale un día entero de depuración más adelante.
+
+**Checkpoint:** `pnpm dev` sirve el esqueleto con cabecera y pie, la ruta inexistente muestra la pantalla de "no encontrado", y la consola está limpia.
+
+---
+
+## Paso 12 · El gate
+
+```bash
+# scripts/verify.sh
+#!/usr/bin/env bash
+# =============================================================================
+# verify.sh — EL gate de calidad.
+# Contrato: exit 0 ⇒ formato + linter sin advertencias + tipos estrictos +
+#           pruebas verdes + build + sin dependencias deprecadas.
+# Lo usan: .husky/pre-commit (--quick), .husky/pre-push (--full) y el CI (--full).
+# Nunca se saltea y nunca se debilita un paso "para que pase": se arregla el código.
+# =============================================================================
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:---full}"
+case "$MODE" in --quick|--full) ;; *) echo "uso: verify.sh [--quick|--full]"; exit 2 ;; esac
+
+BLUE='\033[1;34m'; GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+step() { printf '\n%b▶ %s%b\n' "$BLUE" "$1" "$NC"; }
+fail() { printf '\n%b✖ GATE EN ROJO — %s%b\n' "$RED" "$1" "$NC"; exit 1; }
+START=$(date +%s)
+
+step "[1/5] Formato — Prettier"
+pnpm format:check || fail "hay archivos sin formatear (corran: pnpm format)"
+
+step "[2/5] Linter — ESLint, cero advertencias"
+pnpm lint || fail "el linter encontró problemas"
+
+step "[3/5] Tipos — tsc --noEmit"
+pnpm check-types || fail "errores de tipos"
+
+if [ "$MODE" = "--quick" ]; then
+  printf '\n%b✔ GATE RÁPIDO EN VERDE en %ss%b\n' "$GREEN" "$(( $(date +%s) - START ))" "$NC"; exit 0
+fi
+
+step "[4/5] Pruebas — Vitest"
+pnpm test || fail "pruebas rojas o cobertura por debajo del umbral"
+
+step "[5/5] Build de producción"
+pnpm build || fail "el build falló"
+
+bash scripts/check-versions.sh --gate || fail "hay una dependencia deprecada"
+
+printf '\n%b✔ GATE COMPLETO EN VERDE en %ss%b\n' "$GREEN" "$(( $(date +%s) - START ))" "$NC"
+```
+
+```bash
+chmod +x scripts/verify.sh
+pnpm dlx husky init
+printf 'pnpm lint-staged\nbash scripts/verify.sh --quick\n' > .husky/pre-commit
+printf 'bash scripts/verify.sh --full\n'                     > .husky/pre-push
+```
+
+```jsonc
+// package.json
+"lint-staged": {
+  "*.{ts,tsx}": ["eslint --fix --max-warnings 0", "prettier --write"],
+  "*.{json,css,md}": ["prettier --write"]
+}
+```
+
+`lint-staged` arregla y formatea **los archivos del commit**; `verify.sh --quick` comprueba **el proyecto entero**. Son cosas distintas y por eso están los dos.
+
+**Presupuesto de tiempo:** el gate rápido por debajo de 10 s, el completo por debajo de 90 s. Si el gate rápido tarda medio minuto, alguien va a saltárselo el viernes por la noche y ahí lo perdieron. Si se pone lento, se arregla la causa; **no se quitan pasos**.
+
+```yaml
+# .github/workflows/ci.yml
+name: ci
+on:
+  push: { branches: [main] }
+  pull_request:
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: bash scripts/verify.sh --full
+        env:
+          VITE_TMDB_READ_TOKEN: ${{ secrets.VITE_TMDB_READ_TOKEN }}
+```
+
+El CI corre **el mismo archivo** que sus hooks: es la única forma de que local y CI no puedan separarse. Protejan `main` exigiendo este job.
+
+**Checkpoint, el más importante de la guía:** intenten commitear una variable con tipo `any`. El commit debe ser rechazado. Ese "no" es el producto de todo el paso.
+
+---
+
+## Paso 13 · Cerrar la línea base
+
+```bash
+bash scripts/verify.sh --full
+git add -A && git commit -m "chore: project baseline — tooling, theme, tests and quality gate"
+git push -u origin main
+```
+
+Un `README.md` corto, que un extraño pueda seguir sin preguntarles nada: qué es el proyecto, requisitos, cómo obtener la credencial de TMDB, `pnpm install`, crear `.env.local`, `pnpm dev`, cómo correr las pruebas y el gate, y la atribución a TMDB.
+
+Repasen la lista del principio de este documento. Si las ocho casillas están marcadas, la línea base está terminada y **empieza el proyecto**: el primer archivo que se escribe es del dominio, y ese día no se pinta ninguna pantalla.
+
+---
+
+## Comandos de referencia rápida
+
+```bash
+pnpm dev                          # servidor de desarrollo
+pnpm test:watch                   # pruebas en vivo mientras escriben
+pnpm test                         # pruebas + cobertura (lo que corre el gate)
+pnpm lint                         # linter, cero advertencias
+pnpm check-types                  # tipos
+pnpm format                       # formatear
+bash scripts/verify.sh --quick    # lo que corre en cada commit
+bash scripts/verify.sh --full     # lo que corre antes de cada push y en el CI
+./scripts/check-versions.sh       # versiones y deprecaciones
+pnpm build && pnpm preview        # build de producción, servido para medir
+```
+
+---
+
+## Solución de problemas de la línea base
+
+| Síntoma | Causa | Arreglo |
+|---|---|---|
+| `401` al probar la credencial | Token mal copiado o mandado como clave de v3 | Bearer, y revisen saltos de línea al pegar |
+| Las clases de Tailwind no aplican | Falta el plugin o el `@import` | Plugin en `vite.config.ts` y `@import "tailwindcss"` en `src/index.css` |
+| El linter con reglas de tipo no corre | TypeScript 7 con `typescript-eslint` 8 | Fijen TypeScript 6.0.3 (paso 4) |
+| ESLint no encuentra el proyecto de TS | Falta `projectService` o el directorio raíz | Bloque `languageOptions.parserOptions` del paso 7 |
+| El alias `@/` falla en las pruebas | Falta el plugin de rutas en la config de Vitest | `vite-tsconfig-paths` en `vitest.config.ts` |
+| `matchMedia is not a function` | jsdom no lo implementa | El stub del `vitest.setup.ts` (paso 8) |
+| `ResizeObserver is not defined` | Igual | Mismo archivo |
+| MSW: `request not handled` | No hay simulación para esa URL | Añádanla. El error es la característica, no el fallo |
+| Los hooks de git no se ejecutan | Falta el script `prepare` o `husky init` | Paso 3 y paso 12; después, `pnpm install` otra vez |
+| El gate falla por cobertura con el proyecto vacío | Los umbrales están activados antes de tiempo | Siguen comentados hasta el paso del dominio (paso 8) |
+| `pnpm` no es la versión esperada | Corepack deshabilitado | `corepack enable` y `packageManager` en `package.json` |
+
+---
+
+*Este producto usa la API de TMDB pero no está avalado ni certificado por TMDB.*

--- a/docs/guides/project-guide.md
+++ b/docs/guides/project-guide.md
@@ -1,0 +1,323 @@
+> **Local mirror.** This is a copy of the upstream Cineteca project guide for self-contained reference. The canonical, most up-to-date version lives at <https://gist.github.com/xXAreizaXx/16cb8c169ab015adb0be35fac4992863>. If the two ever diverge, the gist wins.
+
+---
+
+# Cineteca — App web
+
+**Descubrimiento de cine y biblioteca personal · cliente web (solo consumo de API)**
+
+> **Guía del proyecto.** Dice *qué* se construye y *por qué* cada decisión importa. El paso a paso técnico —comandos, archivos, configuración— vive en la **Guía Técnica**. Aquí no hay una sola línea de código a propósito: si una decisión no se puede explicar con palabras, todavía no está entendida.
+
+---
+
+## El encargo
+
+Un cineclub los contrató para construir **Cineteca**: una app web donde la gente descubre películas y arma su propia biblioteca — lo que quiere ver, lo que ya vio, listas temáticas que puede compartir por enlace.
+
+El catálogo ya existe. Es **TMDB**, una API REST pública con quince años de historia y millones de fichas mantenidas por una comunidad. Ustedes no construyen servidor ni base de datos: consumen la API y construyen la experiencia.
+
+Tienen **una semana**. Al cierre, alguien que nunca vio la app tiene que poder abrir un enlace, filtrar el catálogo, buscar por texto, abrir una ficha, guardar películas en su biblioteca y compartir la URL exacta de lo que está viendo — sin que nada se rompa cuando la red se caiga, cuando falte un dato o cuando el navegador esté en alemán.
+
+### El foco, y lo que queda fuera desde el primer día
+
+Este proyecto enseña **una sola cosa bien**: consumir una API ajena con criterio. Validar lo que llega, tratar la caché como una copia que caduca, modelar los estados imposibles fuera del tipo y cubrir los cuatro caminos de cada pantalla.
+
+Por eso **no hay cuentas, ni inicio de sesión, ni roles, ni permisos**. No es que no importen: es que en siete días multiplican la complejidad accidental y tapan la lección de fondo. La biblioteca del usuario vive en **su navegador**, y eso —lejos de ser un atajo— trae su propio problema interesante: el almacenamiento local es otro borde no confiable, y se valida al leer con el mismo rigor que una respuesta de red.
+
+---
+
+## El dominio: estados, dinero y ausencias
+
+El dominio es TypeScript puro: no sabe que existe React, ni Axios, ni el navegador. Eso es lo que lo hace barato de probar y lo que permite exigirle el 100% de cobertura sin dolor.
+
+**Los estados, como conjuntos cerrados de variantes.** El estado de una película y la fiabilidad de su valoración se modelan con uniones discriminadas, y cada rama trae **exactamente** los datos que le corresponden. Al consumirlas, un `switch` con un caso por defecto que el compilador considere inalcanzable obliga a cubrir todas las variantes.
+
+**Las ausencias, explícitas en el tipo.** Ningún `0` ni ninguna cadena vacía de TMDB sobrevive al borde: se traducen a "no hay dato" en el mismo sitio donde se valida la respuesta. De ahí para dentro, el tipo dice la verdad y la pantalla está obligada a tratar el caso.
+
+**El dinero, en enteros.** Un presupuesto no es un número con decimales flotantes —esa aritmética pierde céntimos— sino una cantidad entera en la unidad menor de su moneda, acompañada de la moneda. Tres cosas que hay que interiorizar:
+
+- **Nunca un decimal flotante para dinero.** Enteros en unidades menores, siempre.
+- **Moneda y locale son cosas distintas.** La moneda es un dato de la película (TMDB reporta en dólares); el formato es preferencia de quien mira. Los mismos 63 millones se ven `$63,000,000` con el navegador en inglés de Estados Unidos y `63.000.000 $` con el navegador en alemán, y las dos son correctas.
+- **El formateo no se escribe a mano.** Números, monedas, fechas y plurales los resuelve la API de internacionalización del navegador. Un separador de miles puesto con `replace` es un bug esperando un idioma.
+
+**Las dos reglas que van en el README:** prohibido un número que represente dinero fuera del tipo `Money`; prohibido un `0` que signifique "no lo sé".
+
+---
+
+## El contrato con la API que consumen
+
+**Base:** `https://api.themoviedb.org/3` · **Imágenes:** `https://image.tmdb.org/t/p/{tamaño}{ruta}`, donde el catálogo de tamaños lo entrega el propio endpoint de configuración.
+
+**Credencial.** La app manda una credencial de **solo lectura** en cada petición. Va dentro del bundle, así que es pública: por eso se usa una cuenta de práctica y se puede rotar en un minuto. Compilen la app y busquen la cadena dentro de los archivos generados — la van a encontrar, y ese hallazgo va documentado en el README.
+
+**Errores.** TMDB responde con un código propio que **no coincide** con el código HTTP: "recurso no encontrado" es su código 34 con un 404, y "página inválida" es su código 22 con un 400. Esa traducción se hace una sola vez, en el borde, y de ahí para dentro nadie vuelve a ver un error crudo de la librería HTTP.
+
+**Paginación.** Por número de página, 20 resultados por página y **un tope duro de 500 páginas**: la API no sirve más allá, aunque diga que hay novecientas. Ese tope no es un detalle, es una regla de negocio que su paginación infinita tiene que respetar.
+
+**Límite de tasa.** Unas 50 peticiones por segundo por IP. Ante un `429`, respetar la espera que indica el servidor.
+
+| Endpoint | Para qué |
+|---|---|
+| `GET /configuration` | Base y tamaños de imagen. Se pide una vez y se cachea para siempre |
+| `GET /genre/movie/list` | Catálogo de géneros para los filtros |
+| `GET /discover/movie` | **Descubrimiento con filtros**: género, año, nota mínima, votos mínimos, orden |
+| `GET /search/movie` | Búsqueda por texto |
+| `GET /movie/{id}` | Ficha completa. Con el parámetro de expansión trae elenco y tráilers **en la misma petición** |
+| `GET /movie/{id}/recommendations` | Recomendadas, para la sección inferior de la ficha |
+| `GET /trending/movie/week` | Portada de la pantalla de inicio |
+
+Siete endpoints. Toda la dificultad del proyecto está en cómo los consumen, no en cuántos son.
+
+> **El parámetro de expansión merece su párrafo.** Sin él, pintar una ficha son cuatro viajes a la red; con él, uno. Con el límite de tasa de TMDB y un aula entera compartiendo IP, esa diferencia se nota.
+
+---
+
+## Las pantallas y los cuatro estados
+
+Toda pantalla que muestra datos tiene **cuatro caminos, no uno**. En un buscador, el estado vacío no es un caso raro: es lo que ve la mitad de la gente que filtra demasiado.
+
+| Estado | Qué se muestra |
+|---|---|
+| **Carga** | Un esqueleto con la forma de las tarjetas reales, no un indicador giratorio centrado. El esqueleto comunica qué va a aparecer y evita que el diseño salte cuando llegan los datos |
+| **Error** | Lenguaje llano y un botón de reintento. "No pudimos cargar las películas", no "Error 500". Si es límite de tasa: "vamos demasiado rápido, reintentando en 3 s" |
+| **Vacío inicial** | "Tu cineteca está vacía", con un enlace a explorar. Un vacío sin salida es un callejón |
+| **Vacío por filtro** | "Ninguna película coincide con estos filtros", con un botón para **limpiarlos**. Convertir el callejón en una acción es la mitad del trabajo de experiencia de usuario de este proyecto |
+
+**La tarjeta de película** tiene tres niveles de jerarquía, no uno: el título en semibold, el año y la duración atenuados, y la valoración en su propio nivel tipográfico con su recuento y su plural correcto. El estado nunca se comunica solo con color: una película sin estrenar lleva una etiqueta con texto, no solo un borde gris. Y el póster reserva su proporción **antes** de cargar, para que la cuadrícula no salte.
+
+**Las pantallas y su relación con la URL:**
+
+- **Inicio** — tendencias de la semana y acceso a explorar.
+- **Explorar** — filtros y resultados. **Los filtros viven en la URL**, no en el estado del componente: recargar mantiene la vista y compartir el enlace la reproduce exacta en otro navegador.
+- **Búsqueda** — texto libre con espera antes de consultar.
+- **Ficha de película** — ruta con identificador, pensada para compartirse. Es la URL que la gente manda por chat, así que es una función central del producto, no un extra.
+- **Mi cineteca** — lo guardado, y las listas locales con su detalle.
+
+**El estado de la vista vive en la URL; el estado del servidor vive en la caché.** Entre los dos no queda casi nada, y eso explica por qué en este proyecto no hay un almacén global de estado.
+
+Y un detalle que casi nadie hace: **la URL también es un borde no confiable.** Un filtro con un valor absurdo escrito a mano no puede romper la pantalla; se valida igual que una respuesta de red y se cae con elegancia a los valores por defecto.
+
+---
+
+## Formatos y accesibilidad
+
+**Hay dos internacionalizaciones distintas y confundirlas cuesta un día.** El **contenido** (títulos, sinopsis) lo traduce TMDB si se le pide el idioma en la petición. Los **formatos** (fechas, números, dinero, duraciones, plurales) los resuelve el navegador. Y los **textos de la interfaz** son de ustedes: viven en un módulo de textos, y ninguna cadena visible se escribe suelta dentro de un componente.
+
+La trampa que sale en la evaluación: **la traducción que no existe.** Si la sinopsis llega vacía porque TMDB no la tiene en español, eso no es un error de red ni un hueco: es un estado del producto. Se ofrece la versión en inglés con un aviso claro. Ahí se ve la diferencia entre una app internacional y una traducida a medias.
+
+**Accesibilidad y pruebas son el mismo trabajo:** si un test encuentra un botón por su rol y su nombre, un lector de pantalla también lo encuentra; si hace falta un identificador de prueba para localizarlo, ese botón tampoco es accesible.
+
+- Una tarjeta es **un** enlace con nombre accesible completo: "El padrino, 1972, 8,7 de 10".
+- Al cambiar de ruta, el título del documento cambia y el foco va al encabezado. Sin eso, el lector de pantalla sigue leyendo la página anterior.
+- Los errores de formulario se **anuncian**, no solo se pintan en rojo, y el foco salta al primer campo inválido.
+- Contraste suficiente en todo el texto, incluido el que va sobre un póster, y ningún estado comunicado solo con color.
+- La app aguanta zoom al 200% sin cortes ni scroll horizontal.
+- Todo se alcanza con el teclado. La prueba honesta: guarden el ratón en un cajón y recorran la app entera.
+
+---
+
+## El stack completo
+
+Las versiones son las estables verificadas contra el registry de npm el 19 de agosto de 2026. **La tabla es una foto; el registry es la verdad**: verifíquenlas antes de instalar y usen la última estable que el resto del ecosistema soporte — nunca versiones de prueba.
+
+| Capa | Herramienta | Versión | Por qué |
+|---|---|---|---|
+| Build | **Vite** | 8.2.1 | Arranque instantáneo, recarga en caliente real, build optimizado sin configurar |
+| Lenguaje | **TypeScript** (estricto) | **6.0.3** | **No la 7**: el linter con reglas de tipo todavía no la admite, y ese linter es quien impone la arquitectura. Simbiosis antes que novedad |
+| UI | **React** | 19.2.8 | — |
+| Rutas | **React Router** | 8.3.0 | Rutas anidadas, estado en la URL, carga por ruta |
+| Estilos | **Tailwind CSS** | 4.3.3 | Tokens de diseño en el CSS, sin archivo de configuración |
+| Variantes | **cva** + **tailwind-merge** + **clsx** | 0.7.1 / 3.6.0 / 2.1.1 | Variantes tipadas y fusión de clases sin colisiones |
+| Datos remotos | **TanStack Query** | 5.101.4 | Caché, revalidación, paginación infinita, mutaciones optimistas |
+| Transporte | **Axios** | 1.19.0 | Una sola instancia, interceptores, cancelación |
+| Validación | **Zod** | 4.4.3 | El schema es el tipo. Valida la red, el almacenamiento local y los formularios |
+| Formularios | **React Hook Form** + resolvers | 7.85.0 / 5.9.1 | Renders mínimos; el mismo schema valida y tipa |
+| Virtualización | **@tanstack/react-virtual** | 3.14.10 | Memoria constante con miles de tarjetas |
+| Iconos | **lucide-react** | 1.33.0 | Ligero y con importación selectiva |
+| Errores de UI | **react-error-boundary** | 6.1.3 | Un error de render no deja la pantalla en blanco |
+| Pruebas | **Vitest** + **Testing Library** + **MSW** | 4.1.11 / 16.3.2 / 2.15.0 | Dominio en unitarias, componentes por rol accesible, red simulada en el borde |
+| Calidad | **ESLint** + **typescript-eslint** + **Prettier** | 10.8.1 / 8.67.0 / 3.9.6 | Cero advertencias toleradas |
+| Gate | **Husky** + **lint-staged** + `verify.sh` | 9.1.7 / 17.3.0 | Un commit con un tipo `any` no entra |
+| Paquetes | **pnpm** | 11.22.0 | Instalación rápida y determinista |
+
+**Opcionales, si hacen falta:** las devtools de TanStack Query (ver la caché en vivo vale un día de depuración), el plugin de ESLint para Query, el plugin de accesibilidad para JSX y `axe-core` para automatizar una parte del repaso de accesibilidad.
+
+**Fuera de la lista a propósito:** Redux, Zustand, Jotai. **El estado del servidor lo lleva la caché de Query; el estado de la vista, la URL; la biblioteca, su propio módulo de almacenamiento.** Si al final de la semana necesitan un almacén global, hay algo mal modelado, y esa conversación es parte del ejercicio.
+
+---
+
+## Estructura del proyecto
+
+Clean Architecture, con **la regla de dependencia protegida por el linter**: las dependencias apuntan hacia dentro y el dominio no sabe que existe React.
+
+- **`domain/`** — TypeScript puro. Entidades, estados, políticas, schemas de validación, formateadores, errores. Cero imports de React, de Axios y de la caché.
+- **`application/`** — casos de uso y **puertos**: las interfaces de "algo que trae películas" o "algo que guarda la biblioteca", sin saber cómo lo hacen.
+- **`infrastructure/`** — **implementa** los puertos: el cliente HTTP con sus interceptores, un módulo por recurso que valida lo que llega, y el adaptador del almacenamiento del navegador.
+- **`presentation/`** — React y solo React: rutas, componentes, hooks de datos, proveedores y el módulo de textos.
+
+La duda real de la semana no es qué carpetas hay, sino **dónde va este archivo**. La regla de bolsillo: si un archivo del dominio necesitara instalar algo para funcionar, está en la carpeta equivocada.
+
+**La demostración de 60 segundos:** importen un hook de React dentro del dominio y miren caer el linter. Una regla de arquitectura que solo vive en un diagrama se rompe el jueves; una que vive en el linter y en el CI, no.
+
+---
+
+## Reglas del juego
+
+**El código en inglés, la interfaz en español.** Identificadores, archivos, ramas, commits y tests en inglés. El texto que ve el usuario vive en el módulo de textos.
+
+**Nada entra a `main` sin el gate.** Un solo script corre formato, linter, tipos, pruebas con umbral de cobertura y build — el mismo archivo en su máquina y en el CI, para que no puedan separarse. Tiene presupuesto de tiempo: rápido antes de cada commit, completo antes de cada push. Un gate lento acaba en un `--no-verify` el viernes a las diez de la noche, y ahí lo perdieron.
+
+**Cobertura: 100% en el dominio, 80% global.** El dominio es puro y barato de cubrir. Si un archivo del dominio es difícil de probar, el problema es el diseño, no el test.
+
+**Si no lo pueden explicar, no lo entregan.** Examen oral aleatorio. No poder explicar una función propia línea a línea cuenta como no entregada, por bien que funcione la app.
+
+**El borde se valida siempre, y hay tres bordes:** la red, el almacenamiento local y la URL. Ninguno es de fiar.
+
+**Atribución a TMDB, obligatoria.** Los términos de uso exigen mostrar el logo y la frase correspondiente. No es un detalle estético: es la licencia bajo la que consumen el servicio. Va en el pie de página desde el día 1.
+
+---
+
+## Fuera del alcance
+
+No trabajen en esto, aunque les sobre tiempo:
+
+- **Cuentas, inicio de sesión, roles y permisos.** Es la exclusión deliberada del proyecto: la biblioteca vive en el navegador.
+- **Sincronizar la biblioteca entre dispositivos** o cualquier forma de nube propia.
+- **Un backend o un proxy propio** para ocultar la credencial de lectura.
+- **Series de TV** como sección con pantallas dedicadas.
+- **Modo sin conexión persistente** con service worker.
+
+Si terminan el alcance base, vayan hacia **profundidad, no hacia funciones nuevas**: más estados cubiertos, mejor accesibilidad, más casos límite probados, un buscador más robusto ante la red mala.
+
+---
+
+## Ritmo de la semana
+
+El detalle operativo —comandos, archivos, orden exacto— está en la **Guía Técnica**. Esta es la vista de producto.
+
+| Día | Objetivo | Entregable demostrable |
+|---|---|---|
+| **1** | Cimientos y dominio | Proyecto creado, gate en verde, estados y políticas **con sus pruebas**, sin una sola pantalla |
+| **2** | Primer corte vertical | Explorar con datos reales, sus cuatro estados y los filtros en la URL |
+| **3** | Búsqueda y ficha | Ficha completa con las ausencias visibles como "sin dato", búsqueda con espera, imágenes en el tamaño correcto |
+| **4** | La biblioteca local | Guardar y quitar con vuelta atrás, y el almacenamiento validado al leer |
+| **5** | Listas y formularios | Crear y editar listas locales con formulario validado, con sus dos motivos de bloqueo |
+| **6** | Endurecer | Virtualización, accesibilidad, formatos por locale, cobertura |
+| **7** | Entregar | README, despliegue, repaso del checklist y ensayo del oral |
+
+**La regla del día 1 es la que más cuesta respetar y la que más rinde:** no se pinta nada hasta que el dominio esté modelado y probado. Un día "sin pantallas" se siente improductivo y es el que sostiene los otros seis. Los equipos que se lo saltan llegan al día 5 con la misma regla escrita en cuatro componentes distintos.
+
+---
+
+## Criterios de evaluación
+
+Se evalúa en tres momentos: **el repositorio** (código y commits), **la demo** (10 minutos en un navegador, con la red estrangulada a propósito) y **el oral** (preguntas al azar sobre su propio código). Un mismo trabajo puede sacar 9 en la demo y 3 en el oral: es el mismo esfuerzo mal repartido.
+
+| # | Dimensión | Peso | Qué se mira exactamente |
+|---|---|:--:|---|
+| 1 | **Arquitectura y límites** | 20% | La regla de dependencia se cumple y **el linter la impone**. Ningún componente conoce la librería HTTP. Los puertos existen y las pruebas usan dobles de esos puertos, no de librerías |
+| 2 | **Modelado del dominio y ausencias** | 15% | Uniones discriminadas donde hay estados; los `switch` cubiertos por el compilador; ningún `0` ni cadena vacía de TMDB sobrevive al borde; el dinero en enteros |
+| 3 | **Validación de los tres bordes** | 10% | Red, almacenamiento local y URL, los tres validados. Cero afirmaciones de tipo sin comprobar, cero `any`. Se prueba en vivo: se rompe una respuesta simulada y se mira qué hace la app |
+| 4 | **Datos remotos y caché** | 15% | Claves jerárquicas; filtros normalizados; frescura justificada por tipo de dato; mutación optimista con cancelación, vuelta atrás e invalidación **cruzada**; sin reintentos inútiles; paginación infinita que respeta el tope de la API |
+| 5 | **Formularios** | 10% | Un solo schema que valida y tipa; errores accesibles y en español; envío bloqueado mientras vuela; cada motivo de bloqueo con su propio mensaje, nunca un "no se puede" genérico |
+| 6 | **UI, cuatro estados y accesibilidad** | 15% | Los cuatro estados en **cada** vista con datos; navegación completa por teclado; foco visible; zoom al 200%; contraste suficiente; nada comunicado solo con color |
+| 7 | **Pruebas** | 10% | 100% en el dominio, 80% global. Pruebas que describen comportamiento, no implementación. Deterministas: reloj controlado, cero esperas reales. Un test que nunca falla no prueba nada |
+| 8 | **Proceso y entrega** | 5% | Gate en verde en el CI; commits pequeños; cero `--no-verify`; README que un extraño puede seguir; atribución a TMDB presente |
+
+**Escala por dimensión:** 4 cumple, está probado **y saben explicar la decisión y la alternativa que descartaron** · 3 cumple y está probado, con justificación superficial · 2 funciona en el camino feliz y se cae en un caso límite previsible · 1 presente pero mal aplicado (validar unos endpoints y otros no) · 0 ausente.
+
+Nota final = suma de (nivel ÷ 4 × peso). **Se aprueba con 70%** y con la condición de que ninguna dimensión esté en 0.
+
+### Descalificadores automáticos
+
+Da igual lo bonita que quede la app:
+
+- Un `any` sin comentario que lo justifique, o una supresión muda del compilador.
+- Un `--no-verify` en el historial, o un gate debilitado para que pase.
+- Una respuesta de la API consumida con una afirmación de tipo en vez de validarla.
+- La misma regla decidida en dos sitios: el dominio y un componente.
+- Ausencia de la atribución a TMDB.
+- No poder explicar una función propia en el oral.
+
+### Preguntas típicas del oral
+
+Que sirvan también de guía de estudio: *¿por qué se cancela lo que está en vuelo antes de una actualización optimista?* · *enséñenme la línea exacta donde un `0` de TMDB deja de significar cero* · *¿qué se rompe si el texto del buscador entra crudo en la clave de caché?* · *¿por qué la fecha actual entra por parámetro en la política y no se consulta dentro?* · *si mañana TMDB añade un estado nuevo, ¿qué archivo deja de compilar?* · *¿por qué el almacenamiento local se valida al leer, si lo escribió su propia app?* · *¿qué otras vistas muestran el dato que acaban de mutar?*
+
+---
+
+## Criterios de aceptación · Definition of Done
+
+Se verifica en un navegador real, con las DevTools abiertas y la red estrangulada.
+
+**Funcional**
+
+- [ ] Los cuatro estados en explorar: carga, error, vacío inicial y vacío por filtro
+- [ ] El vacío por filtro ofrece limpiarlos, y al hacerlo vuelve a haber resultados
+- [ ] Recargar con filtros aplicados reproduce la vista exacta; el enlace funciona en otro navegador
+- [ ] Teclear diez letras dispara **una** petición, no diez (con la pestaña de red abierta)
+- [ ] Un filtro con un valor absurdo escrito a mano en la URL no rompe la pantalla
+- [ ] Volver atrás tras guardar algo muestra el estado nuevo, no el viejo
+
+**Datos y red**
+
+- [ ] Toda respuesta se valida; romper un campo en la simulación produce un error localizado y claro
+- [ ] Un límite de tasa no dispara un bucle de reintentos
+- [ ] Guardar en la biblioteca se ve al instante y **se revierte** si la escritura falla
+- [ ] Quitar algo actualiza también la cuadrícula y la pantalla de la biblioteca
+- [ ] La paginación infinita se detiene con un mensaje al llegar al tope de la API
+- [ ] Un dato corrupto en el almacenamiento local se descarta sin tumbar la app
+
+**Datos incompletos**
+
+- [ ] Un presupuesto desconocido se ve como "Sin dato", nunca como "$0"
+- [ ] Una película sin póster tiene marcador de posición, no un icono roto
+- [ ] Una película sin votos dice "Sin valoraciones", no 0,0
+- [ ] Una valoración con pocos votos se distingue visualmente de una consolidada
+- [ ] Una sinopsis ausente en español ofrece la versión en inglés con su aviso
+
+**Formatos**
+
+- [ ] Duración como "2 h 15 min"; votos con separador de miles y plural correcto
+- [ ] Fechas, números y dinero correctos con el navegador en español, en inglés y en alemán
+- [ ] El diseño aguanta el alemán sin romperse
+
+**Accesibilidad**
+
+- [ ] Toda la app es navegable solo con teclado y el foco siempre se ve
+- [ ] Una tarjeta es un enlace con nombre accesible completo
+- [ ] Al cambiar de ruta cambian el título del documento y la posición del foco
+- [ ] Los errores de formulario se anuncian
+- [ ] Zoom al 200% sin cortes ni scroll horizontal; contraste suficiente
+
+**Rendimiento**
+
+- [ ] Scroll fluido con 2.000 tarjetas y memoria que no crece sin techo
+- [ ] Los pósters de la cuadrícula piden el tamaño pequeño, no el original
+- [ ] Sin salto de diseño al cargar las imágenes
+- [ ] Cada ruta se descarga al visitarse; el arranque cabe en el presupuesto
+
+**Entrega**
+
+- [ ] El gate completo en verde, en local y en el CI; `main` protegida
+- [ ] README que un extraño sigue de cero a app corriendo
+- [ ] Desplegada en una URL pública que otra persona abre — incluido un enlace profundo recargado
+- [ ] Atribución a TMDB visible
+
+---
+
+## Cuándo está terminado
+
+Al cierre, su equipo tiene que poder pararse frente a alguien que nunca vio la app, en un navegador real, y mostrarle:
+
+- que puede **explorar el catálogo** con filtros entre miles de resultados, y que el enlace que comparte reproduce exactamente lo que estaba viendo — con los cuatro estados cubiertos;
+- que puede **abrir una ficha** donde un presupuesto desconocido dice "sin dato", una película sin votos no finge un 0,0 y una sin póster no rompe nada;
+- que puede **guardar y organizar** su biblioteca, que el corazón responde antes que el disco y **vuelve solo a su sitio** cuando la escritura falla;
+- que un dato **corrupto o inventado** —en la URL o en el almacenamiento— no tumba la aplicación;
+- que **toda la app se usa con el teclado**, que el lector de pantalla la recorre con sentido y que al 200% de zoom sigue entera;
+- y que otra persona **abre la URL desplegada** y la usa sin que ustedes toquen nada.
+
+Lo que se llevan no es la app: es el criterio para consumir cualquier API con cabeza —validar cada borde, tratar la caché como una copia que caduca, modelar los estados imposibles fuera del tipo, no dejar que un hueco se disfrace de dato— en el siguiente proyecto, con otro dominio y otras herramientas.
+
+---
+
+*Este producto usa la API de TMDB pero no está avalado ni certificado por TMDB.*

--- a/docs/quality-gate.md
+++ b/docs/quality-gate.md
@@ -2,6 +2,8 @@
 
 Nothing reaches `main` or `develop` without the gate running green. The gate is the **same script** locally and in CI: `scripts/verify.sh`. That single fact — local and CI cannot diverge — is the point of the whole quality system.
 
+The gate protects *what* lands in the repo. *How* it lands — which merge strategy per branch — is in [`CONTRIBUTING.md`](../CONTRIBUTING.md#merge-strategy--hybrid-on-purpose).
+
 ---
 
 ## Gate order
@@ -111,6 +113,22 @@ A green local `--full` plus a green CI `gate` check is the only mergeable state.
 
 5. For a coverage failure, open `coverage/index.html` in a browser.
 6. For a dependency deprecation, run `./scripts/check-versions.sh` (without `--gate`) and read the column that says `DEPRECADO`. Replace the package with its documented successor.
+
+---
+
+## Reading the history of `main`
+
+Because `release/* → main` uses a real merge commit (`--no-ff`), `main`'s log contains both the merge commits and the underlying feature commits. The high-level view — one line per release — is recovered with `--first-parent`:
+
+```bash
+# One line per release, just like a squashed history would look
+git log --first-parent main --oneline
+
+# The full graph, for archaeology and git bisect
+git log --mainline parent main --graph --oneline
+```
+
+GitHub's PR diff view for a merge commit shows the same cumulative diff it would show for a squash, so reviewability is unchanged. The difference is invisible at review time and structural at merge time — see [`CONTRIBUTING.md`](../CONTRIBUTING.md#merge-strategy--hybrid-on-purpose).
 
 ---
 

--- a/docs/quality-gate.md
+++ b/docs/quality-gate.md
@@ -125,7 +125,7 @@ Because `release/* → main` uses a real merge commit (`--no-ff`), `main`'s log 
 git log --first-parent main --oneline
 
 # The full graph, for archaeology and git bisect
-git log --mainline parent main --graph --oneline
+git log --graph --oneline main
 ```
 
 GitHub's PR diff view for a merge commit shows the same cumulative diff it would show for a squash, so reviewability is unchanged. The difference is invisible at review time and structural at merge time — see [`CONTRIBUTING.md`](../CONTRIBUTING.md#merge-strategy--hybrid-on-purpose).

--- a/docs/quality-gate.md
+++ b/docs/quality-gate.md
@@ -1,0 +1,145 @@
+# Quality Gate
+
+Nothing reaches `main` or `develop` without the gate running green. The gate is the **same script** locally and in CI: `scripts/verify.sh`. That single fact — local and CI cannot diverge — is the point of the whole quality system.
+
+---
+
+## Gate order
+
+The gate runs in this fixed order. A failure stops the script at the failing step.
+
+```
+1. format      — Prettier (pnpm format:check)
+2. lint        — ESLint, zero warnings (pnpm lint)
+3. types       — tsc --noEmit (pnpm check-types)
+4. tests       — Vitest with coverage (pnpm test)        [full mode only]
+5. build       — Production build (pnpm build)            [full mode only]
+6. dependency  — Deprecated / outdated packages check    [full mode only]
+```
+
+Skipping a step or weakening it "to make it pass" is treated as a process failure, not a technical one.
+
+---
+
+## Modes
+
+`verify.sh` takes one argument: `--quick` or `--full`.
+
+| Mode       | Steps                                                | Used by                                | Target time |
+| ---------- | ---------------------------------------------------- | -------------------------------------- | ----------- |
+| `--quick`  | format → lint → types                                | `.husky/pre-commit`                    | < 10 s      |
+| `--full`   | format → lint → types → tests → build → dependencies | `.husky/pre-push`, `.github/workflows/ci.yml` | < 90 s   |
+
+If either mode grows beyond its budget, **fix the cause**, do not remove steps. A slow gate becomes `--no-verify` on a Friday night and then it stops being a gate.
+
+---
+
+## Local usage
+
+```bash
+# During the inner loop
+bash scripts/verify.sh --quick
+
+# Before pushing
+bash scripts/verify.sh --full
+```
+
+You can also run individual steps on their own to see the full output:
+
+```bash
+pnpm format
+pnpm lint
+pnpm check-types
+pnpm test
+pnpm build
+./scripts/check-versions.sh
+```
+
+---
+
+## Husky hooks
+
+Two hooks live in `.husky/`:
+
+### `pre-commit`
+
+1. `pnpm lint-staged` — runs ESLint `--fix` and Prettier on the staged files only.
+2. `bash scripts/verify.sh --quick` — runs the full project through format, lint, types.
+
+`lint-staged` fixes and formats **the files in this commit**; `verify.sh --quick` checks **the entire project**. They are different things and both are needed.
+
+### `pre-push`
+
+1. `bash scripts/verify.sh --full` — runs the entire gate.
+
+### `commit-msg` (reserved)
+
+A future enhancement is a `commit-msg` hook powered by `@commitlint/cli` to enforce the Conventional Commits format. Wiring this in requires the baseline scaffold (Husky is already initialized) and is tracked separately.
+
+---
+
+## CI
+
+`.github/workflows/ci.yml` runs `bash scripts/verify.sh --full` on:
+
+- every push to `main`
+- every pull request targeting `main` or `develop`
+
+The CI sets `VITE_TMDB_READ_TOKEN` from a repository secret (`Settings → Secrets and variables → Actions`). Branch protection on `main` and `develop` requires the resulting `gate` check to pass before a PR can be merged.
+
+A green local `--full` plus a green CI `gate` check is the only mergeable state.
+
+---
+
+## Reading a failure
+
+1. The script prints the step it failed on, in the format `[3/5] Tipos — tsc --noEmit`.
+2. The failing command's output follows.
+3. The script exits non-zero.
+4. Re-run the failing step on its own to see the full output without the surrounding noise:
+
+   ```bash
+   # For a type failure
+   pnpm check-types
+
+   # For a lint failure
+   pnpm lint
+
+   # For a test failure with coverage report
+   pnpm test
+   ```
+
+5. For a coverage failure, open `coverage/index.html` in a browser.
+6. For a dependency deprecation, run `./scripts/check-versions.sh` (without `--gate`) and read the column that says `DEPRECADO`. Replace the package with its documented successor.
+
+---
+
+## Coverage
+
+Coverage thresholds are deliberately left **commented out** until the domain layer is implemented:
+
+```ts
+// vitest.config.ts → test.coverage.thresholds
+// thresholds: {
+//   lines: 80, functions: 80, branches: 80, statements: 80,
+//   'src/domain/**/*.ts': { lines: 100, functions: 100, branches: 100, statements: 100 },
+// },
+```
+
+When they are uncommented:
+
+- **Domain (`src/domain/**`): 100%** across all four metrics. The domain is pure TypeScript and cheap to test; if a domain file is hard to cover, the design is the problem.
+- **Everything else: 80%** across all four metrics.
+
+---
+
+## What you must never do
+
+- **Never `--no-verify`** to push around a failing commit or pre-push hook.
+- **Never `--max-warnings N` for `N > 0`** in the ESLint config.
+- **Never disable a rule with `// eslint-disable`** without a comment explaining why and a linked issue.
+- **Never `// @ts-expect-error` or `// @ts-ignore`** without a comment explaining why.
+- **Never widen a TypeScript flag** (turn off `noUncheckedIndexedAccess`, etc.) to make code pass.
+- **Never edit `pnpm-lock.yaml` by hand.**
+
+Each of those is a hole in the gate. The whole point of the gate is that holes are not allowed.

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,0 +1,146 @@
+# Tech Stack
+
+The versioned stack that Cineteca runs on, with the rationale for each choice. Versions are verified against the npm registry at the time of writing — re-check before upgrading, because a version table is a snapshot and the registry is the truth. Always use the latest stable release that the rest of the ecosystem supports; never `beta`, `rc`, `canary`, or `next`.
+
+---
+
+## Stack overview
+
+| Layer            | Tool                                                  | Used for                                              |
+| ---------------- | ----------------------------------------------------- | ----------------------------------------------------- |
+| Build            | **Vite**                                              | Dev server, HMR, production build                    |
+| Language         | **TypeScript** (strict)                               | Static types across the codebase                      |
+| UI               | **React**                                             | Component model                                       |
+| Routing          | **React Router**                                      | Nested routes, URL-as-state, route-level code splitting |
+| Styles           | **Tailwind CSS**                                      | Utility-first CSS with design tokens in the CSS file |
+| Variant utilities | **cva** + **tailwind-merge** + **clsx**              | Typed variants, conflict-free class composition      |
+| Server state     | **TanStack Query**                                    | Cache, revalidation, infinite pagination, mutations   |
+| HTTP             | **Axios**                                             | One instance, interceptors, cancellation             |
+| Validation       | **Zod**                                               | Schemas as types — network, storage, URL, forms      |
+| Forms            | **React Hook Form** + **`@hookform/resolvers`**       | Minimal re-renders; Zod schema validates and types    |
+| Virtualization   | **`@tanstack/react-virtual`**                         | Constant memory with thousands of cards               |
+| Icons            | **lucide-react**                                      | Tree-shakable, selectively imported icons             |
+| UI error boundary| **react-error-boundary**                              | A render error cannot blank the screen               |
+| Testing          | **Vitest** + **Testing Library** + **MSW** + **axe-core** | Unit, component, network, accessibility tests     |
+| Quality          | **ESLint** + **typescript-eslint** + **Prettier**     | Linting, type-aware rules, formatting                 |
+| Gate             | **Husky** + **lint-staged** + `scripts/verify.sh`     | Quality gate on every commit and push                 |
+| Package manager  | **pnpm**                                              | Fast, deterministic installs                         |
+
+---
+
+## Why each tool
+
+### Build — Vite
+
+Vite gives near-instant dev startup and real HMR (state-preserving), and produces an optimized build with no extra configuration. The plugin model covers React, TypeScript path aliases, Tailwind, and Vitest config alignment without ad-hoc plumbing.
+
+### Language — TypeScript, strict
+
+Strict mode plus `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noImplicitOverride`, `noFallthroughCasesInSwitch`, `noUnusedLocals`, `noUnusedParameters`, `verbatimModuleSyntax`, and `erasableSyntaxOnly`. These flags catch real bugs:
+
+- `noUncheckedIndexedAccess` makes an access on an empty list typed as "the element **or** undefined", forcing the caller to decide. The single flag that catches the most real bugs in this project.
+- `exactOptionalPropertyTypes` makes the difference between "missing key" and "explicitly undefined" matter at the type level. That difference decides whether a cache key changes.
+
+`typescript-eslint` is the consumer of these flags — it must remain compatible with them, which is why TypeScript itself stays at a version the linter supports.
+
+### UI — React
+
+React for the component model and the ecosystem. Nothing exotic — function components, hooks, error boundaries, strict mode enabled from day one.
+
+### Routing — React Router
+
+Nested routes, URL-as-state, route-level code splitting, loaders, and a clean separation between route configuration and the components it renders.
+
+> Note: React Router 8 is imported from `react-router`, not `react-router-dom`. The `react-router-dom` package is the v7 line. Tutorials that use `react-router-dom` are about the previous major.
+
+### Styles — Tailwind CSS
+
+Tailwind 4 is CSS-first: there is no `tailwind.config.js` file, the design tokens live in `@theme {}` inside `src/index.css`. Three rules follow from this:
+
+1. **Literal color values live only in `@theme`.** A color written by hand inside a component is a leak from the design contract.
+2. **Names are semantic.** `bg-status-unreleased` communicates intent; `bg-amber-500` communicates only a color.
+3. **Classes are composed with a utility, never by string concatenation.** `src/presentation/lib/cn.ts` combines `clsx` and `tailwind-merge` and exports `cn` — two lines that prevent the silent bug of two paddings in one className.
+
+### Variant utilities — cva + tailwind-merge + clsx
+
+- `cva` (class-variance-authority) for typed variants of a component.
+- `clsx` for conditional class composition.
+- `tailwind-merge` to resolve conflicting Tailwind classes deterministically.
+
+### Server state — TanStack Query
+
+Cache, background revalidation, infinite pagination, optimistic mutations, query cancellation, and devtools. Keys are hierarchical and filters are normalized so that two equivalent filter sets hit the same cache entry.
+
+The Query devtools are mounted in development. Seeing the cache live saves a day of debugging later.
+
+### HTTP — Axios
+
+A single instance, interceptors for auth, interceptors for error normalization (TMDB's own status codes do not match HTTP status codes), and request cancellation. Lives in exactly one directory tree: `src/infrastructure/http/**`. The linter rejects `axios` imports anywhere else.
+
+### Validation — Zod
+
+The schema **is** the type. Validates network responses, localStorage reads, URL filters, and forms. `@hookform/resolvers` 5+ is required to talk to Zod 4; older resolvers fail with a type error that is hard to diagnose.
+
+### Forms — React Hook Form + resolvers
+
+Minimal re-renders. The same Zod schema that validates a server response validates the form, so types and validation rules are defined once.
+
+### Virtualization — `@tanstack/react-virtual`
+
+Constant memory with thousands of cards. Combined with smaller poster sizes for the grid, scrolling stays smooth and the layout does not shift.
+
+### Icons — `lucide-react`
+
+Tree-shakable. Icon files import only the icons they use.
+
+### UI error boundary — `react-error-boundary`
+
+A render error never blanks the screen. In development the fallback shows the message; in production it shows the empty state and a retry button.
+
+### Testing — Vitest + Testing Library + MSW + axe-core
+
+- **Vitest** as the test runner, with `jsdom` for the DOM.
+- **Testing Library** for component tests by accessible role and name (not by class or test id).
+- **MSW** to simulate the network at the boundary. `onUnhandledRequest: 'error'` is the feature, not a bug — a request without a handler fails the test instead of leaking to the real network.
+- **axe-core** directly (no thin wrapper) for accessibility assertions. The wrapper packages are unmaintained; the wrapper is twelve lines.
+
+### Quality — ESLint + typescript-eslint + Prettier
+
+- `typescript-eslint`'s strict + stylistic type-checked configs.
+- `eslint-plugin-react-hooks` and `eslint-plugin-jsx-a11y` are not decorations. `jsx-a11y` is the only team member that remembers accessibility at 11 PM on day 6.
+- `eslint-config-prettier` last, to silence everything Prettier owns.
+- `@tanstack/eslint-plugin-query` for Query-specific rules.
+- `--max-warnings 0` everywhere. A warning nobody fixes multiplies until the linter stops reporting. **One warning is a failure.**
+
+### Gate — Husky + lint-staged + `verify.sh`
+
+`scripts/verify.sh` is the single source of truth. Husky's `pre-commit` runs `lint-staged` and `--quick`; `pre-push` runs `--full`. The CI workflow runs `--full` with the same environment. Local and CI cannot diverge — that is the whole point.
+
+### Package manager — pnpm
+
+Fast, deterministic, disk-efficient. The version is pinned via `packageManager` in `package.json` and `corepack enable`; without that, a lockfile generated with a different version produces the classic "works on my machine".
+
+---
+
+## Intentionally excluded
+
+The following are deliberately **not** in the stack:
+
+- **Redux, Zustand, Jotai, MobX.** Server state is in the Query cache; view state is in the URL; the library is its own validated module. If you reach the end of a feature needing a global store, the model is wrong somewhere — that conversation is part of the project.
+- **A custom backend or proxy.** Out of scope for the project; the token is shipped in the bundle and the trade-off is documented in the README.
+- **Service workers for offline persistence.** The localStorage adapter handles current-session persistence; an offline mode with SW is explicitly out of scope.
+- **CSS-in-JS libraries.** Tailwind 4's CSS-first design tokens are the source of truth; a runtime CSS layer would duplicate the design contract.
+
+---
+
+## Verifying versions
+
+```bash
+# Compare installed vs latest stable for every dependency
+./scripts/check-versions.sh
+
+# Same script, but exit non-zero if anything is deprecated
+./scripts/check-versions.sh --gate
+```
+
+The `check-versions.sh` script also fails the gate if any dependency is deprecated. The successor is documented in the script's output and must be migrated to before the next release.


### PR DESCRIPTION
## Summary

This PR ships the **governance + documentation restructure** for the repo. It does not change any product code — it sets up the rules and the surfaces so the next batch of feature work lands on solid ground.

It is the companion PR to six governance issues (#27–#31, #34) that the reviewer and `@3105jero` should read together with this PR. The issues track **what the rules are and why**; this PR delivers the **process documentation and configuration** the rules live in.

> **Replaces #33.** #33 was originally opened from `chore/governance-docs-restructuring`, which was renamed mid-review to `chore/governance-hybrid-and-docs` (see review feedback point 2). GitHub does not allow changing the head ref of an existing PR through the API, so the original PR auto-closed when its head branch was deleted. This PR points at the renamed branch and carries the same body plus the review feedback addressed below.

> **Two iterations on this PR.** The first version of #33 proposed "squash-merge only" for everything. A review caught that this breaks the `develop ↔ main` long-lived relationship (squash creates a brand-new commit with no shared parent — every reverse merge then tries to re-apply the entire diff as new work). The corrected approach is documented in this PR as a **hybrid** strategy. Issues #27 and #29 are updated accordingly, and a new issue #34 adds `.github/dependabot.yml` retargeted to `develop` to eliminate the routine reverse-sync traffic. A second review pass added the four fixes summarized in [Review feedback addressed](#review-feedback-addressed) below.

## What's in this PR

### New files

- **`CONTRIBUTING.md`** — the single source of truth for how work lands in this repo. Covers:
  - Branching model (long-lived `main` / `develop`, short-lived `feature/` / `bugfix/` / `chore/` / `release/` / `hotfix/`) — `#28`
  - **Hybrid merge strategy** — squash for throwaways (`feature`/`bugfix`/`chore` → `develop`), `--no-ff` merge commit for `release/*` and `hotfix/*` into `main` and `develop`, with the rationale and the `git log --first-parent` read — `#29`
  - Conventional Commits format with allowed types, scopes, and examples — `#30`
  - Pull request process (base branch rules, PR template, which merge button per branch)
  - Quality gate overview (links to `docs/quality-gate.md`)
  - Architecture rules summary (links to `docs/architecture.md`)
  - Local setup, issue templates, and references to the project guide and baseline guides (now mirrored locally in `docs/guides/`)
- **`.github/dependabot.yml`** — Dependabot targeting `develop`, with grouped patch/minor and major updates, weekly schedule, and `chore(deps)` commit-message prefix. Eliminates the routine `main → develop` reverse-sync traffic — `#34`
- **`docs/architecture.md`** — Clean Architecture reference. Layer map, import rules, the "where does this file go?" decision table, domain modeling conventions (tagged unions, money as integers, three untrusted edges, four-state model), and how the linter enforces the dependency rule.
- **`docs/tech-stack.md`** — Versioned stack with rationale per tool. Why Vite, why strict TypeScript, why Tailwind 4's CSS-first tokens, why a single Axios instance, why no Redux/Zustand/Jotai, plus the `check-versions.sh` workflow.
- **`docs/quality-gate.md`** — Gate reference. Steps, modes (`--quick` vs `--full`), Husky hooks, CI workflow, time budgets, coverage thresholds, how to read a failure, the explicit list of things you must never do, and the `git log --first-parent main` example for the hybrid strategy.
- **`docs/guides/project-guide.md`** — local mirror of the upstream Cineteca project guide (canonical: gist).
- **`docs/guides/baseline.md`** — local mirror of the upstream Cinética BaseLine guide (canonical: gist).

### Changed files

- **`README.md`** — rewritten in a **narrative, finished-project voice**. It now reads as "this is Cineteca, this is what it does, here is how to run it." Installation steps, scripts, and contributor process are no longer in the README — they live in `CONTRIBUTING.md` and `docs/`. The repo URL is the real one (`https://github.com/Team-Centinela/Project-save-me-of-the-riwi`). TMDB attribution is preserved in its own clear section. References section now links to the local guide mirrors first, with the gists as upstream.

## Why this PR

1. **The README was written as an instructive brief** ("Lo que van a tener al terminar", "Paso 1 · Prerrequisitos", "Tres reglas antes de empezar"), which is appropriate for the assignment gists but wrong for a project README. A README describes a project; instructions live in `CONTRIBUTING.md`; reference material lives in `docs/`.
2. **There was no `CONTRIBUTING.md`**, so the branching, commit, and PR conventions were nowhere on the repo.
3. **There was no `docs/` folder**, so architecture rationale, stack versions, and the quality gate were either buried in the README or only present in the assignment gists.
4. **Branch protection is off** on `main`, and `develop` does not exist yet. Issues #27, #29, and #34 are the proposal to turn that on with the correct hybrid settings. This PR is the documentation and the Dependabot config that make those rules enforceable and reviewable.

## Why the hybrid merge strategy

`feature/*`, `bugfix/*`, and `chore/*` are throwaway — nothing ever merges back into them, so collapsing them into a single squash commit on `develop` is the right call: clean per-feature history, one revert target per PR.

`release/*` and `hotfix/*` are different. They are precisely the bridges between the two long-lived branches (`main` and `develop`) that need to keep exchanging changes for the rest of the project's life. Squash-merging them creates a brand-new commit object whose only parent is the target's HEAD. The two sides of the round-trip no longer share a real ancestor, and the next reverse merge either fails with `fatal: refusing to merge unrelated histories` or produces a long cascade of **phantom conflicts** as Git tries to re-apply the entire diff — even when nothing actually changed.

The fix is `--no-ff` merge commits on those edges. A real merge commit has two parents, so the shared ancestry is preserved. The high-level `git log --first-parent main` view still gives one line per release, exactly like a squashed history would; the granular commits are reachable for `git bisect` and archaeology but don't clutter the daily read.

This is the GitFlow pattern in the AWS Prescriptive Guidance, adapted to GitHub PRs: the `release/*` branch is the intermediary, and it is merged into both `main` and `develop` with real merge commits.

## Review feedback addressed

Thanks to `@3105jero` for the careful review on #33. The following five points are addressed in the latest commit on this branch:

1. **Blocker — broken `git log --mainline parent main` command in `docs/quality-gate.md`.** Fixed to `git log --graph --oneline main`. `--mainline` takes a number; the previous form silently passed `parent` and `main` as revision arguments.
2. **Scope mismatch — PR title and branch used `chore(docs):` but the governance content dominates.** Renamed the branch from `chore/governance-docs-restructuring` to `chore/governance-hybrid-and-docs` and updated the PR title to `chore(governance): split docs, add CONTRIBUTING, hybrid merge strategy, Dependabot on develop`. Both now agree on the `governance` scope.
3. **"Why not squash everything?" walkthrough was directionally correct but vague.** Reworded to name the concrete error modes — `fatal: refusing to merge unrelated histories` and the phantom-conflicts cascade — instead of the previous "tries to re-apply the entire diff" framing.
4. **`prefix-development` in `.github/dependabot.yml` is a no-op for this single-package repo.** Dropped until a real dev-branch workflow exists.
5. **External gist references would 404 silently if the gists are ever moved.** Mirrored both gists into `docs/guides/project-guide.md` and `docs/guides/baseline.md` with attribution headers pointing back to the canonical gists. README and CONTRIBUTING now link to the local copies first, gists as upstream.

## What's intentionally **not** in this PR

- **No branch protection config is changed.** That requires repo admin permissions and is tracked separately in #27.
- **No `develop` branch is created.** It lands with the branch-protection change in #27.
- **No tooling changes.** No `commitlint`, no Husky `commit-msg` hook, no `release-please`. The Conventional Commits convention is **documented only** in this PR; the tooling to enforce it programmatically is filed as a follow-up.
- **No `.gitignore` change.** The repo does not currently have a `.gitignore`, so `node_modules/` and `dist/` are sitting untracked after the bootstrap PRs landed. That is real and worth fixing but it is out of scope for this PR; a small follow-up issue would be the right place.

## Related issues

- **Closes #31** — Split documentation (README / CONTRIBUTING / docs/) — the issue this PR delivers.
- **Closes #34** — Add `.github/dependabot.yml` targeting `develop` — the file this PR adds.
- **Refs #27** — Enable branch protection on `main` and `develop` (linear history OFF) — updated to reflect the hybrid strategy.
- **Refs #28** — Adopt the main / develop / feature/* branching model — the convention referenced from `CONTRIBUTING.md`.
- **Refs #29** — Adopt hybrid merge strategy (squash for throwaways, `--no-ff` for release/hotfix) — updated to reflect the hybrid strategy.
- **Refs #30** — Adopt Conventional Commits for PR titles — the convention documented in `CONTRIBUTING.md`.
- **Supersedes #33** — Previous PR that auto-closed when its head branch was renamed during review.

## How to review

1. Read `CONTRIBUTING.md` end-to-end. It is the entry point for every new contributor.
2. Pay special attention to the new "Merge strategy — hybrid, on purpose" section, which captures the corrected approach.
3. Skim the new `docs/` files (architecture, tech-stack, quality-gate). They are reference material, so depth over breadth.
4. Spot-check `docs/guides/project-guide.md` and `docs/guides/baseline.md` against the upstream gists — they should be byte-identical except for the attribution header.
5. Compare the rewritten `README.md` to the previous version — the goal is narrative voice and concern separation, not new product information.
6. Sanity-check `.github/dependabot.yml` — targets `develop`, groups patch/minor updates, no `prefix-development`.

/cc @3105jero