### PR TITLE
chore(ui): configure tailwind css + theme tokens (#4)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,30 @@
-/* src/index.css — el contrato de diseño del proyecto vive en @theme (paso 6). */
+@import "tailwindcss";
+
+@theme {
+  --color-surface: oklch(0.16 0.02 265);
+  --color-surface-raised: oklch(0.21 0.02 265);
+  --color-ink: oklch(0.97 0.01 265);
+  --color-ink-muted: oklch(0.72 0.02 265);
+  --color-brand: oklch(0.72 0.17 152);
+  --color-danger: oklch(0.63 0.2 25);
+
+  --color-status-released: oklch(0.72 0.17 152);
+  --color-status-unreleased: oklch(0.8 0.15 85);
+  --color-status-unknown: oklch(0.6 0.02 265);
+
+  --text-rating: 1.375rem;
+  --text-rating--line-height: 1.1;
+
+  --spacing-touch: 2.75rem;
+  --radius-card: 0.75rem;
+  --aspect-poster: 2 / 3;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/presentation/lib/cn.ts
+++ b/src/presentation/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
-})
+  plugins: [react(), tailwindcss(), tsconfigPaths()],
+});


### PR DESCRIPTION
## Description

Configures Tailwind CSS 4 with the project's design-contract tokens (CSS-first `@theme`) and ships the `cn()` class-merge utility. This is the **Paso 6** layer from `docs/guides/baseline.md` and is the foundation that every UI component will build on.

Closes #4

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, just code improvement)
- [x] Chore / Maintenance (dependency upgrade, tooling, docs)
- [ ] Performance improvement
- [ ] Test only

## What Changed

- **`vite.config.ts`** — register the `@tailwindcss/vite` plugin between `react()` and `tsconfigPaths()`.
- **`src/index.css`** — replace the placeholder comment with `@import "tailwindcss"`, the `@theme` block defining semantic colors (surface, surface-raised, ink, ink-muted, brand, danger), catalog status colors (released, unreleased, unknown), `text-rating` + line-height, `spacing-touch`, `radius-card`, `aspect-poster`, and a `prefers-reduced-motion` fallback that neutralizes animations and transitions.
- **`src/presentation/lib/cn.ts`** — new two-line utility that composes `clsx` + `tailwind-merge` so component code can merge classes without string concatenation (the silent "two paddings in the same chain" footgun the baseline calls out).

## Affected Layers

- [ ] `domain/` — pure TypeScript, no framework imports
- [ ] `application/` — use cases and ports
- [ ] `infrastructure/` — HTTP, storage, API
- [x] `presentation/` — React, routes, hooks

## Screenshots / Recordings

### Before

N/A — no visual change yet. `src/App.tsx` still renders `<h1>Cineteca</h1>`; Tailwind utilities and `cn()` are wired but not yet consumed by any component (that is the next step in the baseline chain).

### After

N/A — see above.

## How to Test

1. Pull the branch: `git fetch && git checkout chore/tailwind-config`
2. `pnpm install` (no new dependencies; sanity check)
3. `pnpm build` — `dist/assets/index-*.css` should be ~6–7 kB (Tailwind v4 reset + the `@theme` definitions). Confirmed locally: 6.64 kB / 2.10 kB gzipped.
4. `npx tsc --noEmit -p tsconfig.app.json` — should exit 0. Confirmed locally.
5. `pnpm format:check vite.config.ts src/index.css src/presentation/lib/cn.ts` — should pass. Confirmed locally.
6. (Optional, manual) In `src/App.tsx`, replace the body with `<main className="bg-surface text-ink min-h-touch rounded-card p-4">Cineteca</main>` and run `pnpm dev`. The element should render with the dark surface, light ink, 2.75 rem min-height, and 0.75 rem rounded corners from the `@theme` tokens. **Revert before pushing.**

## Tests

- [ ] I added unit tests for the new logic
- [ ] I updated existing tests that no longer apply
- [ ] I verified the manual test plan above
- [x] Coverage has not decreased (no testable logic in this PR; `cn()` is two lines and will be covered transitively once components use it)

`cn()` is intentionally not unit-tested here — it is two lines of well-trodden glue and is exercised transitively the moment any component imports it (the first such import lands in #7 / folder structure).

## Quality Gate

- [x] `pnpm format:check` passes (for the three files touched by this PR; the wider repo has pre-existing prettier drift inherited from #37 that is out of scope here)
- [ ] `pnpm lint` passes (zero warnings) — **not run**: `eslint.config.js` is not on `main` yet; that file lands in #5.
- [x] `pnpm check-types` passes — run via `npx tsc --noEmit -p tsconfig.app.json` because `pnpm check-types` (`tsc --noEmit`) is the broken pre-existing script flagged in PR #35.
- [ ] `pnpm test` passes (coverage thresholds met) — **not run**: no tests in this PR and the Vitest config is part of #6.
- [x] `pnpm build` succeeds — `dist/assets/index-*.css` is 6.64 kB / 2.10 kB gzipped.
- [ ] `./scripts/check-versions.sh` reports no deprecated deps — **not run**: script lands in #10.

## Checklist

- [x] My code follows the project's architecture rules (domain is pure, dependencies point inward)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious
- [ ] I have updated the documentation (README, copy, etc.) if needed
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

_None._ No env vars, no migrations, no config toggles. The change is additive (new plugin, new file, expanded CSS) and `App.tsx` is untouched.

## Reviewer Focus

- `@3105jero` please look at the token values in `src/index.css` lines 4–21 — they are copy-paste from `docs/guides/baseline.md` Paso 6, but if you want to tweak the palette (e.g. swap `--color-brand` from the green to amber to match a cinema aesthetic) this is the cheapest PR to do it in.
- Optional sanity-check: the `vite-tsconfig-paths` deprecation warning at build time is intentional per #2; not addressed here.