### PR TITLE
chore(test): configure vitest, msw, and jsdom polyfills (#6)

### DIFF
--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import App from './App';
+
+describe('App', () => {
+  it('renders the project name as a heading', () => {
+    render(<App />);
+    expect(screen.getByRole('heading', { name: /Cineteca/i })).toBeInTheDocument();
+  });
+});

--- a/src/test/msw/server.ts
+++ b/src/test/msw/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from 'msw/node';
+
+// Starts empty on purpose: every handler is added alongside the feature
+// that needs it, with real API responses as the baseline.
+export const server = setupServer();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,7 +9,7 @@
     "target": "es2023",
     "lib": ["ES2023", "DOM"],
     "module": "esnext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "@testing-library/jest-dom/vitest"],
     "allowArbitraryExtensions": true,
     "skipLibCheck": true,
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.spec.{ts,tsx}', 'src/main.tsx', 'src/**/*.d.ts', 'src/test/**'],
+      // Thresholds are intentionally kept off until the domain layer lands.
+      // Turning them on with an empty scaffold only teaches the gate how to
+      // negotiate with you.
+      // thresholds: {
+      //   lines: 80, functions: 80, branches: 80, statements: 80,
+      //   'src/domain/**/*.ts': { lines: 100, functions: 100, branches: 100, statements: 100 },
+      // },
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react(), tailwindcss(), tsconfigPaths()],
   test: {
     environment: 'jsdom',
     globals: true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
+import { server } from './src/test/msw/server';
+
+// `onUnhandledRequest: 'error'` is what makes MSW useful: a request that
+// nobody simulated blows up the test instead of going to the real network.
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+});
+afterAll(() => {
+  server.close();
+});
+
+// jsdom does not implement either of these, but the theme and the
+// virtualizer expect them.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;


### PR DESCRIPTION
## Description

Sets up the **test runner, MSW for network mocking, and the jsdom polyfills the app needs**. After this lands, `pnpm test` runs a smoke test green, MSW is wired with `onUnhandledRequest: 'error'` so future tests that hit un-simulated URLs will fail loudly instead of silently going to the network, and the spec-file dependency-rule escape hatch from PR #43 has its first real file to exercise.

> **Review feedback addressed in commit `ce9a328`** (on top of the original `d71ded0`):
> - Added the `@tailwindcss/vite` plugin to `vitest.config.ts`. It was missing — the vitest config mirrors the dev plugins, and `vite.config.ts` has had `tailwindcss()` since #4. The smoke test passed regardless because `<h1>Cineteca</h1>` uses no Tailwind classes, but the first feature PR that uses `bg-surface` / `text-ink` / `min-h-touch` / `rounded-card` would have rendered unstyled and the failure would have looked like a component bug rather than a missing config. Caught and fixed before any feature PR lands.
>
> Five non-blocking review items filed as separate issues:
> - **#46** — extract `tsconfig.spec.json` to scope jest-dom matchers to spec files
> - **#47** — replace the `ResizeObserver` double-cast with a typed stub or document the why
> - **#48** — drop the redundant `cleanup()` call from `vitest.setup.ts` (auto-handled in `@testing-library/react@16`)
> - **#49** — pick and document a Vitest convention (globals vs explicit imports)
> - **#50** — update or delete `src/App.spec.tsx` when the app shell lands in #9
>
> The squash merge will collapse both commits into one on `main`; the historical record on the PR is for reviewability.

Closes #6

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, just code improvement)
- [x] Chore / Maintenance (dependency upgrade, tooling, docs)
- [ ] Performance improvement
- [ ] Test only

## What Changed

- **`vitest.config.ts`** (root) — Vitest config with `environment: 'jsdom'`, `globals: true`, `setupFiles: ['./vitest.setup.ts']`, v8 coverage with reporter `text` and `html`, includes `src/**/*.{ts,tsx}`, excludes spec files / `src/main.tsx` / `.d.ts` / `src/test/**`. Coverage **thresholds are intentionally commented out** until the domain layer lands (per the baseline guide — turning them on with an empty scaffold only teaches the gate how to negotiate). **Plugins** mirror `vite.config.ts`: `react(), tailwindcss(), tsconfigPaths()`.
- **`vitest.setup.ts`** (root) — `@testing-library/jest-dom/vitest` for matchers, MSW `server.listen({ onUnhandledRequest: 'error' })` before all tests, `server.resetHandlers()` + `cleanup()` after each, `server.close()` after all. Plus the two jsdom polyfills the theme and virtualizer will need: a fake `window.matchMedia` and a stub `ResizeObserver`.
- **`src/test/msw/server.ts`** — `setupServer()` with no handlers. Handlers are added per-feature when they're needed, alongside the feature that depends on them.
- **`src/App.spec.tsx`** — smoke test. Renders `<App />` and asserts the `Cineteca` heading is in the document. First real consumer of the `*.spec.{ts,tsx}` block from PR #43's eslint config.
- **`tsconfig.app.json`** — extends `types` with `@testing-library/jest-dom/vitest`. Without this, the matcher type augmentation (`toBeInTheDocument` etc.) is invisible to spec files because `vitest.setup.ts` lives at the repo root and isn't in `tsconfig.app.json`'s `include`. The augmentation needs to be loaded by TypeScript at the project level.

## Affected Layers

- [ ] `domain/` — pure TypeScript, no framework imports
- [ ] `application/` — use cases and ports
- [ ] `infrastructure/` — HTTP, storage, API
- [x] `presentation/` — React, routes, hooks

## Screenshots / Recordings

### Before

`pnpm test` errors with:
```
vitest: command not found (vitest is in devDependencies but not configured)
```

### After

```
$ pnpm test

 RUN  v4.1.11 /home/cohorte5/Documentos/ssr_documents/Team-Centinela/Project-save-me-of-the-riwi
      Coverage enabled with v8

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  1.49s
```

## How to Test

1. Pull the branch: `git fetch && git checkout chore/vitest-config`
2. `pnpm install` (no new deps — all are already on `main` from #3)
3. `pnpm test` → "Test Files 1 passed (1), Tests 1 passed (1)"
4. `pnpm test:watch` → watcher starts, smoke test runs and re-runs on save
5. (Optional, MSW smoke) Add a temporary spec file that does `fetch('/api/whatever')` — `onUnhandledRequest: 'error'` will fail the test instead of letting it through to the network.

## Tests

- [ ] I added unit tests for the new logic
- [x] I updated existing tests that no longer apply (no prior tests)
- [x] I verified the manual test plan above
- [x] Coverage has not decreased (no coverage threshold set; v8 report shows only `cn.ts` at 0% because the smoke test doesn't import it)

## Quality Gate

- [x] `pnpm format:check` passes (for the files this PR touches)
- [x] `pnpm lint` passes (zero warnings) — first spec file under the new gate, validates the `*.spec.{ts,tsx}` block works
- [x] `pnpm check-types` passes (run via `npx tsc --noEmit -p tsconfig.app.json`)
- [x] `pnpm test` passes — **this is the gate this PR enables**
- [x] `pnpm build` succeeds — bundle sizes unchanged from #5 (`dist/assets/index-*.css` is still 6.66 kB / 2.10 kB gzipped).
- [ ] `./scripts/check-versions.sh` reports no deprecated deps — **not run**: script lands in #10.

## Checklist

- [x] My code follows the project's architecture rules (domain is pure, dependencies point inward)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious (the `onUnhandledRequest: 'error'` rationale, the coverage-threshold comment, the jsdom-polyfill rationale)
- [x] I have updated the documentation (README, copy, etc.) if needed — `docs/guides/baseline.md` already documents this step
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

_None._ No env vars, no migrations, no config toggles. CI will pick up the new test step automatically when #10 wires the gate.

## Reviewer Focus

- **`vitest.config.ts` plugins** — now `react(), tailwindcss(), tsconfigPaths()`, mirroring `vite.config.ts`. The fix landed in this PR per the review's "1-line fix I'd push into this PR" suggestion.
- **`tsconfig.app.json` `types`** — adding `@testing-library/jest-dom/vitest` makes the matcher augmentation globally available in `src/`. This is intentional for now; **#46** tracks the extraction of `tsconfig.spec.json` to scope it properly.
- **`vitest.setup.ts` `onUnhandledRequest: 'error'`** — strict by default. The first time a feature lands with a fetch call that doesn't have an MSW handler, the test will fail loudly. This is the **feature**, not a bug — per the baseline guide.
- **Coverage thresholds** — commented out per the baseline guide's explicit instruction. When the domain layer lands (#11–#22) and there's real code to cover, this is the place to uncomment.
- **`src/App.spec.tsx`** — minimal. Just renders the existing `<App />` (which is still `<h1>Cineteca</h1>`). When the proper app shell lands in #9, **#50** tracks updating or deleting this test.

## Pre-existing issues this PR surfaces (NOT blockers)

- Same as #5: `pnpm format:check` still fails on `CONTRIBUTING.md`, `README.md`, `docs/**/*.md`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig.json` — drift inherited from #37. Filed as **#42**.
- `tsconfck@3.1.6` deprecation warning at install time — pre-existing, snapshot §6.5.
- `eslint-plugin-jsx-a11y@6.10.2` peer-dep warning — pre-existing, snapshot §6.5; runtime/lint unaffected.