### PR TITLE
chore(gate): add quality gate with verify.sh, husky, lint-staged, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  gate:
+    name: Quality gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run quality gate
+        run: bash scripts/verify.sh --full
+        env:
+          VITE_TMDB_READ_TOKEN: ${{ secrets.VITE_TMDB_READ_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+pnpm lint-staged
+bash scripts/verify.sh --quick

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+bash scripts/verify.sh --full

--- a/package.json
+++ b/package.json
@@ -16,7 +16,17 @@
     "format:check": "prettier --check .",
     "check-types": "tsc --noEmit",
     "test": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix --max-warnings 0",
+      "prettier --write"
+    ],
+    "*.{json,css,md}": [
+      "prettier --write"
+    ]
   },
   "dependencies": {
     "@hookform/resolvers": "5.9.1",

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-versions.sh — Compare installed packages against the latest stable
+# release on the registry and flag deprecated ones.
+# With --gate: exits non-zero if any package is deprecated (used by verify.sh).
+# Without --gate: prints a table for human consumption.
+# =============================================================================
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+GATE="${1:-}"
+FAILED=0
+
+deps=$(node -p "const p=require('./package.json');Object.keys({...p.dependencies,...p.devDependencies}).join('\n')")
+
+printf '%-40s %-14s %-14s %s\n' "PACKAGE" "INSTALLED" "LATEST" "STATUS"
+
+while IFS= read -r dep; do
+  [ -z "$dep" ] && continue
+  installed=$(node -p "try{require('$dep/package.json').version}catch(e){'?'}" 2>/dev/null || echo '?')
+  latest=$(pnpm view "$dep" version 2>/dev/null || echo '?')
+  deprecated=$(pnpm view "$dep" deprecated 2>/dev/null || true)
+  status="ok"
+  if [ -n "$deprecated" ]; then
+    status="DEPRECATED"
+    FAILED=1
+  elif [ "$installed" != "$latest" ] && [ "$installed" != "?" ] && [ "$latest" != "?" ]; then
+    status="has $latest"
+  fi
+  printf '%-40s %-14s %-14s %s\n' "$dep" "$installed" "$latest" "$status"
+done <<< "$deps"
+
+if [ "$GATE" = "--gate" ] && [ "$FAILED" -ne 0 ]; then
+  echo "✖ Deprecated dependencies detected. Replace them with their documented successor." >&2
+  exit 1
+fi

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# =============================================================================
+# verify.sh — THE quality gate.
+# Contract: exit 0 ⇒ format + lint with zero warnings + strict types +
+#           tests green + build succeeds + no deprecated dependencies.
+# Used by: .husky/pre-commit (--quick), .husky/pre-push (--full), and CI (--full).
+# Never skipped, never weakened "to make it pass": fix the code instead.
+# =============================================================================
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:---full}"
+case "$MODE" in
+  --quick | --full) ;;
+  *) echo "usage: verify.sh [--quick|--full]" >&2; exit 2 ;;
+esac
+
+BLUE='\033[1;34m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+step() { printf '\n%b▶ %s%b\n' "$BLUE" "$1" "$NC"; }
+fail() { printf '\n%b✖ GATE RED — %s%b\n' "$RED" "$1" "$NC" >&2; exit 1; }
+
+START=$(date +%s)
+
+step "[1/5] Format — Prettier"
+pnpm format:check || fail "files are not formatted (run: pnpm format)"
+
+step "[2/5] Linter — ESLint, zero warnings"
+pnpm lint || fail "the linter found problems"
+
+step "[3/5] Types — tsc --noEmit"
+pnpm check-types || fail "type errors"
+
+if [ "$MODE" = "--quick" ]; then
+  printf '\n%b✔ QUICK GATE GREEN in %ss%b\n' "$GREEN" "$(( $(date +%s) - START ))" "$NC"
+  exit 0
+fi
+
+step "[4/5] Tests — Vitest with coverage"
+pnpm test || fail "tests failed or coverage below threshold"
+
+step "[5/5] Production build"
+pnpm build || fail "the build failed"
+
+bash scripts/check-versions.sh --gate || fail "a dependency is deprecated"
+
+printf '\n%b✔ FULL GATE GREEN in %ss%b\n' "$GREEN" "$(( $(date +%s) - START ))" "$NC"


### PR DESCRIPTION
# Pull Request

## Description

Wires the project's quality gate end-to-end so a `main` with a warning or a deprecated dependency is no longer possible — the most important task of the baseline. Local hooks and CI run the **same** script (`scripts/verify.sh`); that single fact is the point of the whole quality system.

Closes #10

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, just code improvement)
- [x] Chore / Maintenance (dependency upgrade, tooling, docs)
- [ ] Performance improvement
- [ ] Test only

## What Changed

- **`scripts/verify.sh`** (new, executable) — the single gate script. Two modes:
  - `--quick` runs `pnpm format:check` → `pnpm lint` (zero warnings) → `pnpm check-types`. Target: < 10 s. Used by the pre-commit hook.
  - `--full`  runs `--quick` plus `pnpm test` (Vitest with coverage) → `pnpm build` → `bash scripts/check-versions.sh --gate`. Target: < 90 s. Used by the pre-push hook and CI.
  - The first failing step stops the script, the script names which step, and the script exits non-zero. There is no `|| true` anywhere.
- **`scripts/check-versions.sh`** (new, executable) — prints a table of installed vs latest for every direct dependency, flags any deprecated package, and with `--gate` exits non-zero if anything is deprecated (which is what verify.sh uses). Without `--gate` it's a human-readable report.
- **`.husky/pre-commit`** (new, executable) — runs `pnpm lint-staged` (ESLint `--fix` + Prettier on staged files only) followed by `bash scripts/verify.sh --quick` (the entire project). Two different scopes; both are needed.
- **`.husky/pre-push`** (new, executable) — runs `bash scripts/verify.sh --full`. The whole gate fires before anything leaves the machine.
- **`package.json`**:
  - Adds `"prepare": "husky"` so `pnpm install` wires `core.hooksPath = .husky` for every developer who clones fresh.
  - Adds a top-level `lint-staged` config for `*.{ts,tsx}` (eslint --fix + prettier --write) and `*.{json,css,md}` (prettier --write).
- **`.github/workflows/ci.yml`** (new) — runs the same gate on every push to `main` and every pull request. Ubuntu + Node 22 + pnpm via corepack + `pnpm install --frozen-lockfile` + `bash scripts/verify.sh --full`, with `VITE_TMDB_READ_TOKEN` injected from a repository secret. The `gate` check is the only thing protecting `main` once branch protection is wired (Deployment Notes below).

## Affected Layers

- [x] None — tooling and infrastructure only (scripts, hooks, CI, package.json).

## Screenshots / Recordings

N/A — no UI change.

### Before

```bash
$ bash scripts/verify.sh --quick
bash: scripts/verify.sh: No such file or directory
```

…and CI runs nothing on pull requests; a `main` with a warning can land at any time.

### After

```bash
$ bash scripts/verify.sh --quick

▶ [1/5] Format — Prettier
$ prettier --check .
Checking formatting...
All matched files use Prettier code style!

▶ [2/5] Linter — ESLint, zero warnings
$ eslint . --max-warnings 0

▶ [3/5] Types — tsc --noEmit
$ tsc --noEmit

✔ QUICK GATE GREEN in 27s
```

## How to Test

1. Pull the branch: `git fetch && git checkout chore/gate-add-quality-gate`
2. Run `pnpm install` — this also wires Husky (`prepare` script).
3. Run `bash scripts/verify.sh --quick` → exits 0.
4. Run `bash scripts/verify.sh --full` → exits 0 (format, lint, types, tests, build, no deprecated deps).
5. **Run the 60-second "any" demo** (the acceptance criterion from #10):
   ```bash
   echo 'export const x: any = 1;' > src/domain/_demo_any.ts
   pnpm lint
   # Expected: error "@typescript-eslint/no-explicit-any — Unexpected any."
   rm src/domain/_demo_any.ts
   ```
   This is the rule wired in #43 and made unforgeable by the `--max-warnings 0` flag in the lint script that verify.sh runs.
6. Open the PR — CI runs the same `verify.sh --full` and posts a green `Quality gate` check.

## Tests

- [ ] I added unit tests for the new logic — **N/A**: the gate is a bash wrapper around `pnpm` scripts that already have unit tests. `scripts/verify.sh` and `scripts/check-versions.sh` are shell scripts and not unit-tested in this project (see #44 for the ADR question of whether shell tests would change that).
- [x] I verified the manual test plan above (`--quick` and `--full` both green locally; "any" demo rejects the commit).
- [x] Coverage has not decreased — still 94.73 % lines, 75 % branches on the 19 statements the project has.

## Quality Gate

- [x] `pnpm format:check` passes — `All matched files use Prettier code style!`
- [x] `pnpm lint` passes — 0 errors, 0 warnings (this is the gate this PR enables)
- [x] `pnpm check-types` passes — `tsc --noEmit` exits 0
- [x] `pnpm test` passes — 6 files, 20 tests, 94.73 % lines, 75 % branches, 87.5 % funcs, 94.73 % stmts
- [x] `pnpm build` succeeds — `built in 865ms`, `dist/assets/index-BZqrTi9p.js 370.50 kB / 113.75 kB gzipped`
- [x] `./scripts/check-versions.sh --gate` reports no deprecated deps — all 41 deps `ok` (no `DEPRECATED` rows)

## Checklist

- [x] My code follows the project's architecture rules (no domain code touched)
- [x] I have used the codebase's existing patterns and utilities (mirrors the baseline guide Paso 12 step for step, in English to match the rest of the repo per the #43 review feedback)
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious (block-level comments at the top of each script explain the contract and who uses it)
- [x] I have updated the documentation (README, copy, etc.) if needed — `docs/quality-gate.md` already documents this step; no edits needed there
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

After this lands on `main`, the repo admin (`@3105Jero` per branch-protection ownership) needs to enable the branch-protection rule on `main` that requires the `Quality gate` check before merge:

**Settings → Branches → Branch protection rules → `main`:**

| Setting                                        | Value                                                  |
| ---------------------------------------------- | ------------------------------------------------------ |
| Require a pull request before merging          | **enabled**                                            |
| Required approving reviews                      | 1                                                      |
| Require status checks to pass before merging   | **enabled**, require "Quality gate"                    |
| Require linear history                         | **disabled** (see `CONTRIBUTING.md` — linear history forbids merge commits and would force the squash-only problem back) |
| Include administrators                         | enabled                                                |

This is the only piece of #10 that this PR cannot do from code; it's a GitHub UI step. Once it's set, the rule from `CONTRIBUTING.md` that "every commit on `main` is releasable" is mechanical.

## Reviewer Focus

@3105Jero — three things to look at:

1. **`scripts/verify.sh` step ordering and the `--quick` exit path.** Steps 1–3 always run. Steps 4–5 only run in `--full`. The `--quick` exit prints its own green message and returns 0 without running `check-versions.sh`. Both branches land in a clean exit; the script names every step it tried. Worth eyeballing that the failure semantics are obvious to anyone running it.
2. **`scripts/check-versions.sh` `--gate` mode.** It exits non-zero if any package row reads `DEPRECATED`. It does **not** exit non-zero for rows reading `has $latest` (an outdated-but-not-deprecated upgrade). That's intentional: only `deprecated` is a gate-stopper; outdated-but-supported versions are a Dependabot concern, not a gate concern. If you want outdated to also block, change line 60 (`[ "$installed" != "$latest" ]`) to also `exit 1`. PRs against this behavior are welcome, but worth confirming the intent first.
3. **`package.json` `lint-staged`** runs `eslint --fix --max-warnings 0` then `prettier --write` on staged files only. The `verify.sh --quick` step that runs immediately after checks the **entire** project — they are different scopes, both needed, and the order (lint-staged → verify) is important: lint-staged fixes the staged files first so the project-wide check has the fixes already in place.

---

> By submitting this pull request, I confirm that my contribution is made under the project's license and that I have the right to submit it.