### PR TITLE
feat(infra): add TMDB HTTP client with interceptors and error translation

### DIFF
--- a/src/infrastructure/http/client.spec.ts
+++ b/src/infrastructure/http/client.spec.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+describe('infrastructure/http/client', () => {
+  beforeEach(() => {
+    // resetModules must run before the import below so the client module
+    // re-evaluates with the freshly-stubbed env on every test.
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    vi.useRealTimers();
+  });
+
+  describe('request interceptor', () => {
+    it('returns the JSON body on 200', async () => {
+      server.use(http.get(`${BASE}/3/ping`, () => HttpResponse.json({ ok: true })));
+
+      const { tmdbHttpClient } = await import('./client');
+      const result = await tmdbHttpClient.get<{ ok: boolean }>('/3/ping');
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('attaches the Bearer token from env on every request', async () => {
+      let received: string | null = null;
+      server.use(
+        http.get(`${BASE}/3/whoami`, ({ request }) => {
+          received = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      await tmdbHttpClient.get('/3/whoami');
+      expect(received).toBe(`Bearer ${TOKEN}`);
+    });
+
+    it('sends POST, PUT and DELETE bodies through to the server', async () => {
+      const seen: { method: string; body: string }[] = [];
+      server.use(
+        http.post(`${BASE}/3/echo`, ({ request }) =>
+          request.text().then((body) => {
+            seen.push({ method: 'POST', body });
+            return HttpResponse.json({ ok: true });
+          }),
+        ),
+        http.put(`${BASE}/3/echo`, ({ request }) =>
+          request.text().then((body) => {
+            seen.push({ method: 'PUT', body });
+            return HttpResponse.json({ ok: true });
+          }),
+        ),
+        http.delete(`${BASE}/3/echo`, () => {
+          seen.push({ method: 'DELETE', body: '' });
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      await tmdbHttpClient.post('/3/echo', { a: 1 });
+      await tmdbHttpClient.put('/3/echo', { a: 2 });
+      await tmdbHttpClient.delete('/3/echo');
+
+      expect(seen.map((s) => s.method)).toEqual(['POST', 'PUT', 'DELETE']);
+      expect(seen[0]?.body).toBe(JSON.stringify({ a: 1 }));
+      expect(seen[1]?.body).toBe(JSON.stringify({ a: 2 }));
+    });
+  });
+
+  describe('error translation', () => {
+    it('translates TMDB code 34 + HTTP 404 into notFound', async () => {
+      server.use(
+        http.get(`${BASE}/3/movie/999`, () =>
+          HttpResponse.json(
+            { success: false, status_code: 34, status_message: 'Not found.' },
+            { status: 404 },
+          ),
+        ),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      const promise = tmdbHttpClient.get('/3/movie/999');
+      await expect(promise).rejects.toMatchObject({
+        name: 'TmdbHttpError',
+        detail: { kind: 'notFound', message: 'Not found.' },
+      });
+    });
+
+    it('translates TMDB code 22 + HTTP 400 into invalidPage', async () => {
+      server.use(
+        http.get(`${BASE}/3/discover/movie`, () =>
+          HttpResponse.json(
+            { success: false, status_code: 22, status_message: 'Invalid page.' },
+            { status: 400 },
+          ),
+        ),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      await expect(tmdbHttpClient.get('/3/discover/movie')).rejects.toMatchObject({
+        detail: { kind: 'invalidPage', message: 'Invalid page.' },
+      });
+    });
+
+    it('translates TMDB codes 7/10/30/31 into invalidApiKey', async () => {
+      server.use(
+        http.get(`${BASE}/3/configuration`, () =>
+          HttpResponse.json(
+            { success: false, status_code: 7, status_message: 'Invalid API key.' },
+            { status: 401 },
+          ),
+        ),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      await expect(tmdbHttpClient.get('/3/configuration')).rejects.toMatchObject({
+        detail: { kind: 'invalidApiKey', message: 'Invalid API key.' },
+      });
+    });
+
+    it('translates HTTP 5xx into serverError with the status', async () => {
+      server.use(
+        http.get(`${BASE}/3/anything`, () =>
+          HttpResponse.json({ status_message: 'Internal error.' }, { status: 500 }),
+        ),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      await expect(tmdbHttpClient.get('/3/anything')).rejects.toMatchObject({
+        detail: { kind: 'serverError', status: 500, message: 'Internal error.' },
+      });
+    });
+
+    it('translates an unknown 4xx into unknown (no recognised TMDB code)', async () => {
+      server.use(
+        http.get(`${BASE}/3/weird`, () =>
+          HttpResponse.json({ status_message: 'Weird.' }, { status: 418 }),
+        ),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      await expect(tmdbHttpClient.get('/3/weird')).rejects.toMatchObject({
+        detail: { kind: 'unknown', status: 418, message: 'Weird.' },
+      });
+    });
+
+    it('falls back to the HTTP status when the body has no status_message', async () => {
+      server.use(http.get(`${BASE}/3/empty`, () => HttpResponse.json({}, { status: 503 })));
+
+      const { tmdbHttpClient } = await import('./client');
+      await expect(tmdbHttpClient.get('/3/empty')).rejects.toMatchObject({
+        detail: { kind: 'serverError', status: 503 },
+      });
+    });
+
+    it('falls back to "Network error" when there is no response', async () => {
+      server.use(http.get(`${BASE}/3/down`, () => HttpResponse.error()));
+
+      const { tmdbHttpClient } = await import('./client');
+      await expect(tmdbHttpClient.get('/3/down')).rejects.toMatchObject({
+        name: 'TmdbHttpError',
+        detail: { kind: 'networkError' },
+      });
+    });
+
+    it('translateError falls back to "Network error" when no message or response.status is available', async () => {
+      // Direct unit test for the defensive branch in messageFor.
+      const { translateError } = await import('./errors');
+      const error = translateError({});
+      expect(error).toMatchObject({
+        detail: { kind: 'networkError', message: 'Network error' },
+      });
+    });
+  });
+
+  describe('rate-limit handling (429)', () => {
+    it('retries once with the server-indicated Retry-After and succeeds', async () => {
+      let calls = 0;
+      server.use(
+        http.get(`${BASE}/3/throttled`, () => {
+          calls += 1;
+          if (calls === 1) {
+            return new HttpResponse(JSON.stringify({ status_message: 'Slow down.' }), {
+              status: 429,
+              headers: { 'retry-after': '0' },
+            });
+          }
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      const result = await tmdbHttpClient.get<{ ok: boolean }>('/3/throttled');
+      expect(result).toEqual({ ok: true });
+      expect(calls).toBe(2);
+    });
+
+    it('translates to rateLimited when the retry also fails', async () => {
+      server.use(
+        http.get(
+          `${BASE}/3/throttled-forever`,
+          () =>
+            new HttpResponse(JSON.stringify({ status_message: 'Slow down.' }), {
+              status: 429,
+              headers: { 'retry-after': '0' },
+            }),
+        ),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      await expect(tmdbHttpClient.get('/3/throttled-forever')).rejects.toMatchObject({
+        detail: { kind: 'rateLimited', retryAfterSeconds: 0 },
+      });
+    });
+
+    it('defaults retry-after to 1 second when the header is missing', async () => {
+      vi.useFakeTimers();
+      let calls = 0;
+      server.use(
+        http.get(`${BASE}/3/no-header`, () => {
+          calls += 1;
+          if (calls === 1) {
+            return new HttpResponse(JSON.stringify({ status_message: 'Slow down.' }), {
+              status: 429,
+            });
+          }
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const { tmdbHttpClient } = await import('./client');
+      const promise = tmdbHttpClient.get<{ ok: boolean }>('/3/no-header');
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result).toEqual({ ok: true });
+      expect(calls).toBe(2);
+    });
+  });
+});

--- a/src/infrastructure/http/client.ts
+++ b/src/infrastructure/http/client.ts
@@ -1,0 +1,116 @@
+/**
+ * TMDB HTTP client — the only place in the codebase that knows axios.
+ *
+ * The dependency rule (`eslint.config.js`) bans `axios` imports outside
+ * `src/infrastructure/http/**`. Every TMDB call goes through
+ * `tmdbHttpClient`, which is responsible for:
+ *
+ *  1. Attaching the read-only token from `env` on every request.
+ *  2. Retrying once on `429` after the server-indicated `Retry-After`.
+ *  3. Translating every failure into a `TmdbHttpError` with a
+ *     discriminated `kind` — the rest of the app never sees raw axios.
+ *
+ * Tests cover the request interceptor (auth header), the retry path,
+ * and every translation branch. MSW intercepts the calls so no real
+ * network is hit.
+ *
+ * @see Cineteca.md — "Límite de tasa", "Errores".
+ */
+
+import axios, {
+  type AxiosError,
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type AxiosResponse,
+} from 'axios';
+import { env } from '@/config/env';
+import { TmdbHttpError, translateError } from './errors';
+
+// Module augmentation: flag a retried request so the response interceptor
+// can detect "we already gave 429 a second chance". Without this, a
+// pathological 429 on the retry would loop forever.
+declare module 'axios' {
+  export interface InternalAxiosRequestConfig {
+    __tmdbRetried?: boolean;
+  }
+}
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function attachInterceptors(instance: AxiosInstance): void {
+  // Request interceptor — inject the bearer token on every call. The
+  // token comes from the validated env so a missing or malformed token
+  // fails at startup, not at the first request.
+  instance.interceptors.request.use((config) => {
+    config.headers.set('Authorization', `Bearer ${env.VITE_TMDB_READ_TOKEN}`);
+    return config;
+  });
+
+  // Response interceptor — two responsibilities:
+  //  - On 429 with Retry-After, wait and retry exactly once.
+  //  - On any other failure (including the failed retry), translate
+  //    to a typed TmdbHttpError so the caller never sees axios shape.
+  instance.interceptors.response.use(
+    (response): AxiosResponse => response,
+    async (error: AxiosError): Promise<AxiosResponse> => {
+      const config = error.config;
+      const response = error.response;
+      const isRateLimited = response?.status === 429;
+
+      if (isRateLimited && config && !config.__tmdbRetried) {
+        config.__tmdbRetried = true;
+        const headers = response.headers as Record<string, string | undefined>;
+        const retryAfterHeader = headers['retry-after'] ?? '';
+        const parsed = Number.parseInt(retryAfterHeader, 10);
+        const seconds = Number.isFinite(parsed) && parsed >= 0 ? parsed : 1;
+        await sleep(seconds * 1000);
+        // The retry hits the same interceptor. __tmdbRetried=true
+        // prevents another retry, so the inner rejection is already
+        // a TmdbHttpError — let it propagate without re-translating.
+        return instance.request(config);
+      }
+
+      throw translateError(error);
+    },
+  );
+}
+
+function createTmdbHttpInstance(): AxiosInstance {
+  const instance = axios.create({
+    baseURL: env.VITE_TMDB_API_BASE,
+    timeout: REQUEST_TIMEOUT_MS,
+  });
+  attachInterceptors(instance);
+  return instance;
+}
+
+const tmdbHttpInstance = createTmdbHttpInstance();
+
+/**
+ * Surface for the rest of the app. Thin wrapper around the singleton
+ * axios instance that returns the response body directly (no
+ * `{ data, status, headers, … }` envelope at the call site).
+ *
+ * On failure the promise rejects with a `TmdbHttpError`.
+ */
+export const tmdbHttpClient = {
+  get: <T>(url: string, config?: AxiosRequestConfig): Promise<T> =>
+    tmdbHttpInstance.get<T>(url, config).then((response) => response.data),
+
+  post: <T>(url: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> =>
+    tmdbHttpInstance.post<T>(url, body, config).then((response) => response.data),
+
+  put: <T>(url: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> =>
+    tmdbHttpInstance.put<T>(url, body, config).then((response) => response.data),
+
+  delete: <T>(url: string, config?: AxiosRequestConfig): Promise<T> =>
+    tmdbHttpInstance.delete<T>(url, config).then((response) => response.data),
+};
+
+export { TmdbHttpError };

--- a/src/infrastructure/http/errors.ts
+++ b/src/infrastructure/http/errors.ts
@@ -1,0 +1,157 @@
+/**
+ * TMDB error types — the boundary translation.
+ *
+ * TMDB returns errors in two layers: an HTTP status (4xx/5xx) and a body
+ * with its own numeric `status_code` and a `status_message`. The numeric
+ * codes do not match HTTP — "resource not found" is TMDB code 34 with
+ * HTTP 404, and "invalid page" is TMDB code 22 with HTTP 400.
+ *
+ * This file is the single place that translates a raw Axios failure
+ * into a typed `TmdbHttpError` carrying a discriminated kind. The rest
+ * of the app handles the kind, never the raw Axios shape.
+ *
+ * @see Cineteca.md — "Errores".
+ */
+
+export type TmdbError =
+  | { readonly kind: 'notFound'; readonly message: string }
+  | { readonly kind: 'invalidPage'; readonly message: string }
+  | {
+      readonly kind: 'invalidApiKey';
+      readonly message: string;
+    }
+  | {
+      readonly kind: 'rateLimited';
+      readonly message: string;
+      readonly retryAfterSeconds: number;
+    }
+  | {
+      readonly kind: 'serverError';
+      readonly status: number;
+      readonly message: string;
+    }
+  | { readonly kind: 'networkError'; readonly message: string }
+  | {
+      readonly kind: 'unknown';
+      readonly status: number;
+      readonly message: string;
+    };
+
+/**
+ * Thrown by the HTTP client on any failure. Carries the discriminated
+ * `detail` so callers can pattern-match on `kind` instead of inspecting
+ * HTTP statuses or TMDB numeric codes.
+ */
+export class TmdbHttpError extends Error {
+  override name = 'TmdbHttpError' as const;
+  readonly detail: TmdbError;
+
+  constructor(detail: TmdbError) {
+    super(detail.message);
+    this.detail = detail;
+  }
+}
+
+interface TmdbErrorBody {
+  readonly status_code?: number;
+  readonly status_message?: string;
+}
+
+function isTmdbErrorBody(value: unknown): value is TmdbErrorBody {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    (v.status_code === undefined || typeof v.status_code === 'number') &&
+    (v.status_message === undefined || typeof v.status_message === 'string')
+  );
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function readBody(error: { response?: { data?: unknown } }): TmdbErrorBody {
+  const data = error.response?.data;
+  return isTmdbErrorBody(data) ? data : {};
+}
+
+function messageFor(error: { message?: string; response?: { status?: number } }): string {
+  if (typeof error.message === 'string' && error.message.length > 0) {
+    return error.message;
+  }
+  if (typeof error.response?.status === 'number') {
+    return `HTTP ${String(error.response.status)}`;
+  }
+  return 'Network error';
+}
+
+/**
+ * Translate a TMDB / HTTP failure into a `TmdbHttpError`. Called by
+ * the client once the retry path has given up.
+ *
+ * - `429` → `rateLimited` (with the server-indicated retry-after).
+ * - TMDB body codes 22, 34, 7/10/30/31 → mapped kinds (the ones
+ *   documented in Cineteca.md plus the auth-related cluster).
+ * - HTTP 5xx → `serverError`.
+ * - HTTP 4xx without a recognised TMDB code → `unknown`.
+ * - No response (network failure) → `networkError`.
+ *
+ * The mapping for TMDB body codes is intentionally partial: the
+ * documentation only covers a handful of codes, and the rest fall
+ * through to the HTTP-status fallback. A future issue can extend
+ * the table if a feature needs it.
+ */
+export function translateError(error: {
+  message?: string;
+  response?: {
+    status?: number;
+    data?: unknown;
+    headers?: Record<string, string | undefined>;
+  };
+}): TmdbHttpError {
+  const status = error.response?.status;
+  const body = readBody(error);
+  const code = asNumber(body.status_code, Number.NaN);
+  const message = asString(body.status_message, messageFor(error));
+
+  if (status === 429) {
+    const retryAfterHeader = error.response?.headers?.['retry-after'];
+    const parsed = Number.parseInt(retryAfterHeader ?? '', 10);
+    // Retry-After is a positive integer in seconds (per RFC 9110). A
+    // value of 0 is valid and means "retry immediately"; only a
+    // missing, non-numeric, or negative header falls back to 1.
+    const retryAfterSeconds = Number.isFinite(parsed) && parsed >= 0 ? parsed : 1;
+    return new TmdbHttpError({
+      kind: 'rateLimited',
+      message,
+      retryAfterSeconds,
+    });
+  }
+
+  if (!Number.isNaN(code)) {
+    if (code === 22) {
+      return new TmdbHttpError({ kind: 'invalidPage', message });
+    }
+    if (code === 34) {
+      return new TmdbHttpError({ kind: 'notFound', message });
+    }
+    if (code === 7 || code === 10 || code === 30 || code === 31) {
+      return new TmdbHttpError({ kind: 'invalidApiKey', message });
+    }
+  }
+
+  if (typeof status === 'number') {
+    if (status >= 500) {
+      return new TmdbHttpError({ kind: 'serverError', status, message });
+    }
+    return new TmdbHttpError({ kind: 'unknown', status, message });
+  }
+
+  return new TmdbHttpError({ kind: 'networkError', message });
+}


### PR DESCRIPTION
# Pull Request

## Description

Issue #23 builds the single Axios instance the rest of the codebase talks to. The dependency rule (`eslint.config.js`) bans `axios` imports outside `src/infrastructure/http/**`; this PR fills that directory with the only piece of code allowed to know axios.

Closes #23

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## What Changed

- `src/infrastructure/http/errors.ts` — `TmdbError` discriminated union + `TmdbHttpError` class + `translateError()` that turns a raw Axios failure into a typed error carrying `kind: 'notFound' | 'invalidPage' | 'invalidApiKey' | 'rateLimited' | 'serverError' | 'networkError' | 'unknown'`
- `src/infrastructure/http/client.ts` — singleton axios instance with two interceptors:
  - **Request**: injects `Authorization: Bearer ${env.VITE_TMDB_READ_TOKEN}` on every call
  - **Response**: retries once on 429 with the server-indicated `Retry-After` (defaults to 1s); translates every other failure into `TmdbHttpError`
- `src/infrastructure/http/client.ts` — exports `tmdbHttpClient` (typed `get` / `post` / `put` / `delete` that return response bodies, not axios envelopes) and re-exports `TmdbHttpError`
- `src/infrastructure/http/client.spec.ts` — 13 tests via MSW: auth header, every translation branch, 429 retry-then-succeed, 429 retry-then-fail, missing-Retry-After default
- `src/infrastructure/http/.gitkeep` — removed (directory now has real files)

## Affected Layers

- [x] `infrastructure/` — HTTP, storage, API
- No `domain/` or `presentation/` changes.

## Screenshots / Recordings

N/A — no UI.

## How to Test

1. Pull the branch: `git fetch && git checkout feature/infra-http-client-interceptors`
2. Run `pnpm install`
3. Run `pnpm test` — expect 97 passing, http module ~98% lines / 89% branches
4. Run `bash scripts/verify.sh --full` — expect green in ~70s

Spot-checks worth running by hand (in a Vitest REPL or temporary test):

```ts
// Happy path
const { tmdbHttpClient } = await import('./src/infrastructure/http/client');
const data = await tmdbHttpClient.get('/3/configuration'); // throws if env not set

// Error path
try {
  await tmdbHttpClient.get('/3/missing');
} catch (e) {
  // e.detail.kind === 'notFound'
}
```

## Tests

- [x] I added unit tests for the new logic
- [ ] I updated existing tests that no longer apply (none affected)
- [x] I verified the manual test plan above
- [x] Coverage has not decreased (global 98.77% statements / 91.66% branches; http module 98.5% lines / 88.5% branches)

## Quality Gate

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm check-types` passes
- [x] `pnpm test` passes (coverage thresholds met)
- [x] `pnpm build` succeeds
- [x] `./scripts/check-versions.sh` reports no deprecated deps

Local run: `bash scripts/verify.sh --full` → `✔ FULL GATE GREEN in 69s`.

## Checklist

- [x] My code follows the project's architecture rules (axios is imported only in `infrastructure/http/`; the linter would reject any other location)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious
- [x] I have read the Cineteca Project Guide and the Baseline Guide

## Deployment Notes

None. The client is only used by code that doesn't exist yet (the resource adapters under `src/infrastructure/api/<resource>/`); nothing in the existing app shell imports it. The PR is a foundation for #12.

## Reviewer Focus

A few decisions worth a second look:

- **`TmdbHttpError` as a class, not a tagged value.** The rest of the app needs to `throw` it, and `unknown` rejection patterns are easier to debug when the error has a `.name`. The discriminated `detail.kind` is what consumers actually pattern-match on.
- **`__tmdbRetried` module augmentation.** A `boolean` flag on `InternalAxiosRequestConfig` via `declare module 'axios'`. The alternative was a `WeakMap<InternalAxiosRequestConfig, boolean>`, which is heavier and harder to debug. This is the lightest non-leaky option.
- **Translation table is partial.** TMDB's documented codes (22, 34, 7/10/30/31) are mapped explicitly; everything else falls through to HTTP-status-based kinds (5xx → `serverError`, other 4xx → `unknown`). The comment in `translateError` flags this as a deliberate scope choice — extending the table is a one-PR change when a feature needs it.
- **`Retry-After` default of 1 second, and `0` is valid.** `Number.parseInt('0', 10) === 0`, which `> 0` rejected; I switched the condition to `>= 0` so the server can ask for an immediate retry. Missing/non-numeric/negative headers fall back to 1 second.
- **Module-level singleton.** The issue said "single Axios instance" — I went with `const tmdbHttpInstance = createTmdbHttpInstance()`. Tests get a fresh instance per test via `vi.resetModules()` + dynamic import; this is the same pattern `env.spec.ts` uses.
- **No tooling or governance changes folded in this time.** Scoped strictly to `src/infrastructure/http/` per the reviewer feedback on PR #67.

---

> By submitting this pull request, I confirm that my contribution is made under the project's license and that I have the right to submit it.