### PR TITLE
feat(infra): add per-endpoint TMDB API modules with Zod validation

### DIFF
--- a/src/domain/configuration/app-configuration.spec.ts
+++ b/src/domain/configuration/app-configuration.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import type { AppConfiguration } from './app-configuration';
+
+describe('domain/configuration/app-configuration', () => {
+  it('wraps the image configuration and exposes change_keys', () => {
+    const config: AppConfiguration = {
+      images: {
+        baseUrl: 'http://image.tmdb.org/t/p',
+        secureBaseUrl: 'https://image.tmdb.org/t/p',
+        posterSizes: ['w185'],
+        backdropSizes: ['w1280'],
+        profileSizes: ['w185'],
+        stillSizes: ['w300'],
+        logoSizes: ['w300'],
+      },
+      changeKeys: ['adult', 'air_date', 'also_known_as'],
+    };
+    expect(config.images.secureBaseUrl).toBe('https://image.tmdb.org/t/p');
+    expect(config.changeKeys).toContain('adult');
+  });
+});

--- a/src/domain/configuration/app-configuration.ts
+++ b/src/domain/configuration/app-configuration.ts
@@ -1,0 +1,16 @@
+import { type ImageConfiguration } from '@/domain/configuration/image-configuration';
+
+/**
+ * AppConfiguration — the TMDB `/configuration` response, normalized.
+ *
+ * Today only `images` is used; tomorrow a future feature may need
+ * `change_keys` (e.g. the kinds of fields TMDB allows you to append).
+ * Keeping the full shape now means a future change is purely
+ * additive on the consumer side.
+ *
+ * @see Cineteca.md — "Base y tamaños de imagen".
+ */
+export interface AppConfiguration {
+  readonly images: ImageConfiguration;
+  readonly changeKeys: readonly string[];
+}

--- a/src/domain/configuration/image-configuration.spec.ts
+++ b/src/domain/configuration/image-configuration.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import type { ImageConfiguration } from './image-configuration';
+
+describe('domain/configuration/image-configuration', () => {
+  it('carries the secure base and the per-type size lists', () => {
+    const config: ImageConfiguration = {
+      baseUrl: 'http://image.tmdb.org/t/p',
+      secureBaseUrl: 'https://image.tmdb.org/t/p',
+      posterSizes: ['w92', 'w154', 'w185', 'w342', 'w500', 'w780', 'original'],
+      backdropSizes: ['w300', 'w780', 'w1280', 'original'],
+      profileSizes: ['w45', 'w185', 'h632', 'original'],
+      stillSizes: ['w92', 'w185', 'w300', 'original'],
+      logoSizes: ['w45', 'w92', 'w154', 'w185', 'w300', 'w500', 'original'],
+    };
+    expect(config.secureBaseUrl).toBe('https://image.tmdb.org/t/p');
+    expect(config.posterSizes).toContain('w500');
+    expect(config.posterSizes).toContain('original');
+  });
+});

--- a/src/domain/configuration/image-configuration.ts
+++ b/src/domain/configuration/image-configuration.ts
@@ -1,0 +1,27 @@
+/**
+ * ImageConfiguration — the size catalogue for image URLs.
+ *
+ * TMDB's `/configuration` endpoint hands back a list of sizes for
+ * each image type (poster, backdrop, profile, still, logo). Every
+ * application URL is built as
+ *   `${baseUrl}/${size}${path}`
+ * where `path` is what the per-resource endpoints return (e.g.
+ * `/abc.jpg`).
+ *
+ * Keeping this shape in the domain means the UI can build URLs
+ * without depending on TMDB's response layout. The
+ * `secureBaseUrl` is what production uses; `baseUrl` is here only
+ * to keep the contract round-trippable when reading the cached
+ * response back from storage in a future issue.
+ *
+ * @see Cineteca.md — "Base y tamaños de imagen".
+ */
+export interface ImageConfiguration {
+  readonly baseUrl: string;
+  readonly secureBaseUrl: string;
+  readonly posterSizes: readonly string[];
+  readonly backdropSizes: readonly string[];
+  readonly profileSizes: readonly string[];
+  readonly stillSizes: readonly string[];
+  readonly logoSizes: readonly string[];
+}

--- a/src/domain/movie/cast.spec.ts
+++ b/src/domain/movie/cast.spec.ts
@@ -1,0 +1,24 @@
+import { absent, present } from '@/domain/shared/no-data';
+import { describe, expect, it } from 'vitest';
+import type { CastMember } from './cast';
+
+describe('domain/movie/cast', () => {
+  it('carries absent or present wraps for character and profile', () => {
+    const withEverything: CastMember = {
+      id: 1,
+      name: 'Keanu Reeves',
+      character: present('Neo'),
+      profilePath: present('/path.jpg'),
+    };
+    const withNothing: CastMember = {
+      id: 2,
+      name: 'Unknown',
+      character: absent<string>(),
+      profilePath: absent<string>(),
+    };
+
+    expect(withEverything.character).toEqual({ kind: 'present', value: 'Neo' });
+    expect(withNothing.character).toEqual({ kind: 'absent' });
+    expect(withNothing.profilePath.kind).toBe('absent');
+  });
+});

--- a/src/domain/movie/cast.ts
+++ b/src/domain/movie/cast.ts
@@ -1,0 +1,19 @@
+import { type NoData } from '@/domain/shared/no-data';
+
+/**
+ * CastMember — a credited actor on a movie.
+ *
+ * The `character` field carries the role played and is often empty for
+ * cameos or uncredited work; the `profilePath` carries the headshot.
+ * Both wrap `NoData` so the type itself says whether the data is
+ * present or absent — TMDB sends `null` for "no data" and the
+ * validation edge translates that.
+ *
+ * @see docs/architecture.md — "Absences are explicit in the type".
+ */
+export interface CastMember {
+  readonly id: number;
+  readonly name: string;
+  readonly character: NoData<string>;
+  readonly profilePath: NoData<string>;
+}

--- a/src/domain/movie/genre.spec.ts
+++ b/src/domain/movie/genre.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import type { Genre } from './genre';
+
+describe('domain/movie/genre', () => {
+  it('carries the id and the name as readonly fields', () => {
+    const genre: Genre = { id: 28, name: 'Action' };
+    expect(genre.id).toBe(28);
+    expect(genre.name).toBe('Action');
+  });
+});

--- a/src/domain/movie/genre.ts
+++ b/src/domain/movie/genre.ts
@@ -1,0 +1,13 @@
+/**
+ * Genre — a TMDB movie genre.
+ *
+ * The id is what matters at the filter layer; the name is what the
+ * UI shows. The shape is shared between `/genre/movie/list` and the
+ * per-movie `genres` array on the detail response.
+ *
+ * @see Cineteca.md — "El contrato con la API que consumen".
+ */
+export interface Genre {
+  readonly id: number;
+  readonly name: string;
+}

--- a/src/domain/movie/movie-detail.spec.ts
+++ b/src/domain/movie/movie-detail.spec.ts
@@ -1,0 +1,39 @@
+import { absent, present } from '@/domain/shared/no-data';
+import { iso4217 } from '@/domain/money/iso-4217';
+import { moneyFromMajor } from '@/domain/money/money';
+import { released } from '@/domain/movie/movie-state';
+import { describe, expect, it } from 'vitest';
+import { type MovieDetail } from './movie-detail';
+
+describe('domain/movie/movie-detail', () => {
+  it('extends MovieSummary with detail fields and uses NoData for absent ones', () => {
+    const detail: MovieDetail = {
+      id: 1,
+      title: 'Inception',
+      overview: 'A thief who steals corporate secrets.',
+      posterPath: present('/poster.jpg'),
+      backdropPath: absent<string>(),
+      state: released(new Date('2010-07-16T00:00:00Z')),
+      rating: { kind: 'consolidated', votes: 1000, average: 8.4 },
+      genreIds: [28, 12],
+      tagline: present('Your mind is the scene of the crime.'),
+      runtime: present(148),
+      genres: [
+        { id: 28, name: 'Action' },
+        { id: 12, name: 'Adventure' },
+      ],
+      budget: present(moneyFromMajor(160_000_000, iso4217('USD'))),
+      revenue: present(moneyFromMajor(836_800_000, iso4217('USD'))),
+      cast: present([]),
+      trailers: absent<readonly never[]>(),
+    };
+
+    expect(detail.runtime).toEqual({ kind: 'present', value: 148 });
+    expect(detail.budget).toEqual({
+      kind: 'present',
+      value: { amount: 16_000_000_000, currency: iso4217('USD') },
+    });
+    expect(detail.cast).toEqual({ kind: 'present', value: [] });
+    expect(detail.trailers.kind).toBe('absent');
+  });
+});

--- a/src/domain/movie/movie-detail.ts
+++ b/src/domain/movie/movie-detail.ts
@@ -1,0 +1,40 @@
+import { type NoData } from '@/domain/shared/no-data';
+import { type Money } from '@/domain/money/money';
+import { type CastMember } from '@/domain/movie/cast';
+import { type Genre } from '@/domain/movie/genre';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { type Trailer } from '@/domain/movie/trailer';
+
+/**
+ * MovieDetail — the rich record behind a single movie.
+ *
+ * Extends `MovieSummary` with everything the detail screen needs but
+ * the summary does not: tagline, runtime, resolved `Genre` objects
+ * (the summary carries `genreIds` instead, to keep the response light
+ * in lists), budget and revenue as `Money` integers, and the appended
+ * cast and trailers.
+ *
+ * `cast` and `trailers` are wrapped in `NoData<readonly …[]>` so the
+ * domain distinguishes "the API call did not ask for the append"
+ * (translated to `absent`) from "the call asked but the movie has
+ * no credits / no videos" (which the API still returns as an empty
+ * array, wrapped in `present([])`). The UI can pattern-match on
+ * `kind` to decide whether to render the section at all.
+ *
+ * The same `Money` rule as elsewhere: amount in the smallest
+ * currency unit, never a raw decimal. TMDB reports budget and
+ * revenue as JSON numbers in USD; the validation edge converts.
+ *
+ * @see docs/architecture.md — "Money as integers", "Absences are
+ *      explicit in the type".
+ * @see Cineteca.md — "El parámetro de expansión".
+ */
+export interface MovieDetail extends MovieSummary {
+  readonly tagline: NoData<string>;
+  readonly runtime: NoData<number>;
+  readonly genres: readonly Genre[];
+  readonly budget: NoData<Money>;
+  readonly revenue: NoData<Money>;
+  readonly cast: NoData<readonly CastMember[]>;
+  readonly trailers: NoData<readonly Trailer[]>;
+}

--- a/src/domain/movie/movie-summary.spec.ts
+++ b/src/domain/movie/movie-summary.spec.ts
@@ -1,0 +1,87 @@
+import { absent, present } from '@/domain/shared/no-data';
+import { describe, expect, it } from 'vitest';
+import { classifyRelease, ratingFromVotes, type MovieSummary } from './movie-summary';
+
+describe('domain/movie/movie-summary', () => {
+  describe('type shape', () => {
+    it('accepts the composed readonly fields', () => {
+      const summary: MovieSummary = {
+        id: 1,
+        title: 'Inception',
+        overview: 'A thief who steals corporate secrets.',
+        posterPath: present('/poster.jpg'),
+        backdropPath: absent<string>(),
+        state: { kind: 'released', releaseDate: new Date('2010-07-16T00:00:00Z') },
+        rating: { kind: 'consolidated', votes: 1000, average: 8.4 },
+        genreIds: [28, 12],
+      };
+      expect(summary.id).toBe(1);
+      expect(summary.title).toBe('Inception');
+      expect(summary.state.kind).toBe('released');
+    });
+  });
+
+  describe('classifyRelease', () => {
+    const now = new Date('2024-06-01T00:00:00Z');
+
+    it('returns unknown for null and undefined', () => {
+      expect(classifyRelease(null, now).kind).toBe('unknown');
+      expect(classifyRelease(undefined, now).kind).toBe('unknown');
+    });
+
+    it('returns unknown for an empty string', () => {
+      expect(classifyRelease('', now).kind).toBe('unknown');
+    });
+
+    it('returns unknown for an unparseable date', () => {
+      expect(classifyRelease('not-a-date', now).kind).toBe('unknown');
+    });
+
+    it('returns released for a past date and carries the parsed Date', () => {
+      const result = classifyRelease('2010-07-16', now);
+      expect(result.kind).toBe('released');
+      if (result.kind !== 'released') {
+        throw new Error('expected released');
+      }
+      expect(result.releaseDate.toISOString()).toBe('2010-07-16T00:00:00.000Z');
+    });
+
+    it('returns released for "today" (the present is not the future)', () => {
+      expect(classifyRelease('2024-06-01', now)).toEqual({
+        kind: 'released',
+        releaseDate: new Date('2024-06-01T00:00:00Z'),
+      });
+    });
+
+    it('returns unreleased for a strictly-future date and carries the parsed Date', () => {
+      const result = classifyRelease('2099-12-31', now);
+      expect(result.kind).toBe('unreleased');
+      if (result.kind !== 'unreleased') {
+        throw new Error('expected unreleased');
+      }
+      expect(result.expectedReleaseDate.toISOString()).toBe('2099-12-31T00:00:00.000Z');
+    });
+
+    it('defaults "now" to the current time when not provided', () => {
+      const past = new Date(Date.now() - 86_400_000);
+      const iso = past.toISOString().slice(0, 10);
+      expect(classifyRelease(iso).kind).toBe('released');
+    });
+  });
+
+  describe('ratingFromVotes', () => {
+    it('delegates to the domain rating helper', () => {
+      expect(ratingFromVotes(0, 0)).toEqual({ kind: 'unknown' });
+      expect(ratingFromVotes(10, 9.0)).toEqual({
+        kind: 'early',
+        votes: 10,
+        average: 9.0,
+      });
+      expect(ratingFromVotes(10_000, 8.5)).toEqual({
+        kind: 'consolidated',
+        votes: 10_000,
+        average: 8.5,
+      });
+    });
+  });
+});

--- a/src/domain/movie/movie-summary.ts
+++ b/src/domain/movie/movie-summary.ts
@@ -1,0 +1,80 @@
+import { type NoData } from '@/domain/shared/no-data';
+import {
+  type MovieState,
+  released,
+  unreleased,
+  unknownMovieState,
+} from '@/domain/movie/movie-state';
+import { ratingReliability, type RatingReliability } from '@/domain/rating/rating-reliability';
+
+/**
+ * MovieSummary — a movie as it appears in lists and search results.
+ *
+ * Composes the existing domain primitives (`MovieState`,
+ * `RatingReliability`, `NoData<T>`) and adds nothing. The translation
+ * from TMDB to this shape happens at the validation edge in
+ * `infrastructure/api/`; the domain stays free of TMDB.
+ *
+ * Field mapping from TMDB:
+ *  - `id`               → `id`
+ *  - `title`            → `title`
+ *  - `overview`         → `overview` (may be empty, translated to `''`)
+ *  - `poster_path`      → `posterPath` (null → `absent`)
+ *  - `backdrop_path`    → `backdropPath` (null → `absent`)
+ *  - `release_date`     → `state` (empty → `unknown`, past → released,
+ *                          future → unreleased)
+ *  - `vote_average`     → `rating.average` (only when vote_count > 0)
+ *  - `vote_count`       → `rating.votes` (0 → `unknown` rating)
+ *  - `genre_ids`        → `genreIds`
+ *
+ * @see docs/architecture.md — "States as discriminated unions".
+ * @see Cineteca.md — "Estados, dinero, ausencia".
+ */
+export interface MovieSummary {
+  readonly id: number;
+  readonly title: string;
+  readonly overview: string;
+  readonly posterPath: NoData<string>;
+  readonly backdropPath: NoData<string>;
+  readonly state: MovieState;
+  readonly rating: RatingReliability;
+  readonly genreIds: readonly number[];
+}
+
+/**
+ * Classify a release date from TMDB into a `MovieState`.
+ *
+ * The rule is mechanical, not a calendar lookup:
+ *  - missing / empty string → `unknown`
+ *  - parseable date in the future (strictly after "now") → `unreleased`
+ *  - anything else (parseable in the past or present, unparseable)
+ *    → `released` with the parsed date, or `unknown` if unparseable.
+ *
+ * "Now" is captured at the API edge, so the same input date
+ * deterministically produces the same variant for a given moment.
+ */
+export function classifyRelease(
+  rawReleaseDate: string | null | undefined,
+  now: Date = new Date(),
+): MovieState {
+  if (typeof rawReleaseDate !== 'string' || rawReleaseDate.length === 0) {
+    return unknownMovieState();
+  }
+  const parsed = new Date(rawReleaseDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return unknownMovieState();
+  }
+  if (parsed.getTime() > now.getTime()) {
+    return unreleased(parsed);
+  }
+  return released(parsed);
+}
+
+/**
+ * Build a `RatingReliability` from a TMDB-shaped `vote_count` / `vote_average`
+ * pair. Translates `vote_count === 0` to `unknown` so the type carries the
+ * truth instead of leaving a meaningless "0 of 10" rating in the system.
+ */
+export function ratingFromVotes(voteCount: number, voteAverage: number): RatingReliability {
+  return ratingReliability(voteCount, voteAverage);
+}

--- a/src/domain/movie/paginated.spec.ts
+++ b/src/domain/movie/paginated.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import type { PaginatedList } from './paginated';
+
+describe('domain/movie/paginated', () => {
+  it('is a structural type: a concrete value satisfies the contract', () => {
+    const list: PaginatedList<number> = {
+      page: 1,
+      results: [1, 2, 3],
+      totalPages: 2,
+      totalResults: 6,
+    };
+    expect(list.page).toBe(1);
+    expect(list.results).toEqual([1, 2, 3]);
+    expect(list.totalPages).toBe(2);
+    expect(list.totalResults).toBe(6);
+  });
+});

--- a/src/domain/movie/paginated.ts
+++ b/src/domain/movie/paginated.ts
@@ -1,0 +1,17 @@
+/**
+ * PaginatedList — a page of items out of a larger collection.
+ *
+ * TMDB caps pagination at 500 pages and treats that as a hard limit,
+ * not a soft suggestion; downstream consumers enforce it. The shape
+ * matches what every paginated endpoint returns so API modules can
+ * share one Zod schema.
+ *
+ * @see Cineteca.md — "Paginación".
+ * @see docs/architecture.md — "Absences are explicit in the type".
+ */
+export interface PaginatedList<T> {
+  readonly page: number;
+  readonly results: readonly T[];
+  readonly totalPages: number;
+  readonly totalResults: number;
+}

--- a/src/domain/movie/trailer.spec.ts
+++ b/src/domain/movie/trailer.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import type { Trailer } from './trailer';
+
+describe('domain/movie/trailer', () => {
+  it('carries the TMDB video id as a string', () => {
+    const trailer: Trailer = {
+      id: '65a4dcfaa30835e0384bd97b',
+      key: '4Vk3f1P0YYM',
+      site: 'YouTube',
+      type: 'Trailer',
+      name: 'Official Trailer',
+    };
+    expect(trailer.id).toBe('65a4dcfaa30835e0384bd97b');
+    expect(trailer.key).toBe('4Vk3f1P0YYM');
+    expect(trailer.site).toBe('YouTube');
+    expect(trailer.type).toBe('Trailer');
+    expect(trailer.name).toBe('Official Trailer');
+  });
+});

--- a/src/domain/movie/trailer.ts
+++ b/src/domain/movie/trailer.ts
@@ -1,0 +1,20 @@
+/**
+ * Trailer — a video clip hosted on a third-party site.
+ *
+ * TMDB aggregates metadata for videos hosted on YouTube, Vimeo, and
+ * a handful of others; only `site === 'YouTube'` is rendered by
+ * Cineteca today, but the field stays open-ended in the type so a
+ * new host does not need a code change.
+ *
+ * The `id` from TMDB is a string (Mongo-style hex), not a number —
+ * differs from movie and people ids.
+ *
+ * @see Cineteca.md — "El parámetro de expansión".
+ */
+export interface Trailer {
+  readonly id: string;
+  readonly key: string;
+  readonly site: string;
+  readonly type: string;
+  readonly name: string;
+}

--- a/src/infrastructure/api/_shared.ts
+++ b/src/infrastructure/api/_shared.ts
@@ -1,0 +1,201 @@
+/**
+ * Internal helpers shared by every API module.
+ *
+ * Convention:
+ *   - `tmdb*Schema` — raw Zod schema for a TMDB JSON shape.
+ *   - `to*`        — raw → domain mapper (pure, total, deterministic).
+ *
+ * Underscore prefix is a code-reading convention: API modules
+ * import from here, the rest of the app does not. The architecture
+ * table forbids outside-layer imports of `infrastructure/*` directly.
+ */
+
+import { z } from 'zod';
+import { iso4217 } from '@/domain/money/iso-4217';
+import { moneyFromMajor } from '@/domain/money/money';
+import { type NoData, absent, present } from '@/domain/shared/no-data';
+import { type CastMember } from '@/domain/movie/cast';
+import { type Genre } from '@/domain/movie/genre';
+import { type MovieDetail } from '@/domain/movie/movie-detail';
+import { type MovieSummary, classifyRelease, ratingFromVotes } from '@/domain/movie/movie-summary';
+import { type RatingReliability } from '@/domain/rating/rating-reliability';
+import { type Trailer } from '@/domain/movie/trailer';
+
+// =============================================================================
+// Raw TMDB Zod schemas
+// =============================================================================
+//
+// All TMDB fields are typed as `unknown` until the schema narrows
+// them. Nullable strings come back as `null`, empty strings, or
+// absent; money fields as numbers (`0` means "no data"); dates as
+// strings (`''` means unknown). Each mapper normalizes these to
+// the domain's `NoData`, `Money`, or `MovieState` types.
+
+export const tmdbMovieSummarySchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  overview: z.string(),
+  poster_path: z.union([z.string(), z.null()]),
+  backdrop_path: z.union([z.string(), z.null()]),
+  release_date: z.union([z.string(), z.null()]),
+  vote_average: z.number(),
+  vote_count: z.number(),
+  genre_ids: z.array(z.number()),
+});
+
+const tmdbGenreSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+const tmdbCastMemberSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  character: z.union([z.string(), z.null()]),
+  profile_path: z.union([z.string(), z.null()]),
+});
+
+const tmdbTrailerSchema = z.object({
+  id: z.string(),
+  key: z.string(),
+  site: z.string(),
+  type: z.string(),
+  name: z.string(),
+});
+
+const tmdbDetailAppendagesSchema = z.object({
+  credits: z
+    .object({ cast: z.array(tmdbCastMemberSchema) })
+    .nullable()
+    .optional(),
+  videos: z
+    .object({ results: z.array(tmdbTrailerSchema) })
+    .nullable()
+    .optional(),
+});
+
+export const tmdbMovieDetailFullSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  overview: z.string(),
+  poster_path: z.union([z.string(), z.null()]),
+  backdrop_path: z.union([z.string(), z.null()]),
+  release_date: z.union([z.string(), z.null()]),
+  vote_average: z.number(),
+  vote_count: z.number(),
+  genre_ids: z.array(z.number()),
+  tagline: z.union([z.string(), z.null()]),
+  runtime: z.union([z.number().nonnegative(), z.null()]),
+  genres: z.array(tmdbGenreSchema),
+  budget: z.union([z.number().nonnegative(), z.null()]),
+  revenue: z.union([z.number().nonnegative(), z.null()]),
+  credits: tmdbDetailAppendagesSchema.shape.credits,
+  videos: tmdbDetailAppendagesSchema.shape.videos,
+});
+
+// =============================================================================
+// Raw → domain mappers (pure, total)
+// =============================================================================
+
+function noDataFromNullableString(value: string | null): NoData<string> {
+  // TMDB signals "no string here" with both `null` and `''` for the
+  // same field, depending on the endpoint. The domain collapses
+  // both into `absent` — a present empty string is never useful.
+  return value === null || value.length === 0 ? absent<string>() : present(value);
+}
+
+function noDataFromNullableNumber(raw: number | null): NoData<number> {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) {
+    return absent<number>();
+  }
+  return present(raw);
+}
+
+function noDataFromMoney(raw: number | null): NoData<ReturnType<typeof moneyFromMajor>> {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) {
+    return absent();
+  }
+  return present(moneyFromMajor(raw, iso4217('USD')));
+}
+
+function toRating(voteCount: number, voteAverage: number): RatingReliability {
+  return ratingFromVotes(voteCount, voteAverage);
+}
+
+function toGenres(rawArr: readonly z.infer<typeof tmdbGenreSchema>[]): readonly Genre[] {
+  return rawArr.map((g) => ({ id: g.id, name: g.name }));
+}
+
+function toCast(rawArr: readonly z.infer<typeof tmdbCastMemberSchema>[]): readonly CastMember[] {
+  return rawArr.map((c) => ({
+    id: c.id,
+    name: c.name,
+    character: noDataFromNullableString(c.character),
+    profilePath: noDataFromNullableString(c.profile_path),
+  }));
+}
+
+function toTrailers(rawArr: readonly z.infer<typeof tmdbTrailerSchema>[]): readonly Trailer[] {
+  return rawArr.map((t) => ({
+    id: t.id,
+    key: t.key,
+    site: t.site,
+    type: t.type,
+    name: t.name,
+  }));
+}
+
+/**
+ * Translates a single TMDB raw movie object into a domain
+ * `MovieSummary`. `now` is injectable so tests can pin the
+ * `released` / `unreleased` boundary to a known instant.
+ */
+export function toMovieSummary(raw: unknown, now: Date = new Date()): MovieSummary {
+  const parsed = tmdbMovieSummarySchema.parse(raw);
+  return {
+    id: parsed.id,
+    title: parsed.title,
+    overview: parsed.overview,
+    posterPath: noDataFromNullableString(parsed.poster_path),
+    backdropPath: noDataFromNullableString(parsed.backdrop_path),
+    state: classifyRelease(parsed.release_date, now),
+    rating: toRating(parsed.vote_count, parsed.vote_average),
+    genreIds: parsed.genre_ids,
+  };
+}
+
+/**
+ * Translates a TMDB raw `/movie/{id}` response (with or without
+ * the `append_to_response=credits,videos` extension) into a
+ * domain `MovieDetail`. `now` is injectable for testing.
+ */
+export function toMovieDetail(raw: unknown, now: Date = new Date()): MovieDetail {
+  const parsed = tmdbMovieDetailFullSchema.parse(raw);
+
+  const cast: NoData<readonly CastMember[]> =
+    parsed.credits === null || parsed.credits === undefined
+      ? absent<readonly CastMember[]>()
+      : present(toCast(parsed.credits.cast));
+  const trailers: NoData<readonly Trailer[]> =
+    parsed.videos === null || parsed.videos === undefined
+      ? absent<readonly Trailer[]>()
+      : present(toTrailers(parsed.videos.results));
+
+  return {
+    id: parsed.id,
+    title: parsed.title,
+    overview: parsed.overview,
+    posterPath: noDataFromNullableString(parsed.poster_path),
+    backdropPath: noDataFromNullableString(parsed.backdrop_path),
+    state: classifyRelease(parsed.release_date, now),
+    rating: toRating(parsed.vote_count, parsed.vote_average),
+    genreIds: parsed.genre_ids,
+    tagline: noDataFromNullableString(parsed.tagline),
+    runtime: noDataFromNullableNumber(parsed.runtime),
+    genres: toGenres(parsed.genres),
+    budget: noDataFromMoney(parsed.budget),
+    revenue: noDataFromMoney(parsed.revenue),
+    cast,
+    trailers,
+  };
+}

--- a/src/infrastructure/api/configuration.spec.ts
+++ b/src/infrastructure/api/configuration.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+const handlerPath = `${BASE}/3/configuration`;
+
+const validResponse = () => ({
+  images: {
+    base_url: 'http://image.tmdb.org/t/p',
+    secure_base_url: 'https://image.tmdb.org/t/p',
+    poster_sizes: ['w92', 'w185', 'w500', 'original'],
+    backdrop_sizes: ['w300', 'w1280', 'original'],
+    profile_sizes: ['w45', 'w185', 'original'],
+    still_sizes: ['w92', 'w300', 'original'],
+    logo_sizes: ['w45', 'w300', 'original'],
+  },
+  change_keys: ['adult', 'air_date', 'also_known_as'],
+});
+
+describe('infrastructure/api/configuration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('fetches /3/configuration and maps to a domain AppConfiguration', async () => {
+    server.use(http.get(handlerPath, () => HttpResponse.json(validResponse())));
+
+    const { getAppConfiguration } = await import('./configuration');
+    const config = await getAppConfiguration();
+
+    expect(config.images.secureBaseUrl).toBe('https://image.tmdb.org/t/p');
+    expect(config.images.posterSizes).toContain('w500');
+    expect(config.images.backdropSizes).toEqual(['w300', 'w1280', 'original']);
+    expect(config.changeKeys).toContain('adult');
+  });
+
+  it('caches the result across calls so the network is hit once', async () => {
+    let calls = 0;
+    server.use(
+      http.get(handlerPath, () => {
+        calls += 1;
+        return HttpResponse.json(validResponse());
+      }),
+    );
+
+    const { getAppConfiguration } = await import('./configuration');
+    const first = await getAppConfiguration();
+    const second = await getAppConfiguration();
+
+    expect(first).toBe(second);
+    expect(calls).toBe(1);
+  });
+
+  it('throws a ZodError (caught by the caller) when the response breaks the schema', async () => {
+    // Simulate a TMDB shape change: missing `change_keys`.
+    server.use(
+      http.get(handlerPath, () =>
+        HttpResponse.json({
+          images: {
+            base_url: 'http://image.tmdb.org/t/p',
+            secure_base_url: 'https://image.tmdb.org/t/p',
+            poster_sizes: ['w185'],
+            backdrop_sizes: ['w1280'],
+            profile_sizes: ['w185'],
+            still_sizes: ['w300'],
+            logo_sizes: ['w300'],
+          },
+        }),
+      ),
+    );
+
+    const { getAppConfiguration } = await import('./configuration');
+    // The cache has now stored a rejected promise. Clear it so a
+    // retry in this test does not see the previous failure.
+    await expect(getAppConfiguration()).rejects.toThrow();
+  });
+
+  it('surfaces HTTP errors raised by the underlying client (e.g. 404)', async () => {
+    server.use(
+      http.get(handlerPath, () =>
+        HttpResponse.json(
+          { success: false, status_code: 34, status_message: 'Not found.' },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    const { getAppConfiguration } = await import('./configuration');
+    await expect(getAppConfiguration()).rejects.toMatchObject({
+      name: 'TmdbHttpError',
+      detail: { kind: 'notFound' },
+    });
+  });
+
+  it('clears the cache when __resetConfigurationCacheForTests is called', async () => {
+    let calls = 0;
+    server.use(
+      http.get(handlerPath, () => {
+        calls += 1;
+        return HttpResponse.json(validResponse());
+      }),
+    );
+
+    const { getAppConfiguration, __resetConfigurationCacheForTests } =
+      await import('./configuration');
+    await getAppConfiguration();
+    await getAppConfiguration();
+    expect(calls).toBe(1);
+
+    __resetConfigurationCacheForTests();
+    await getAppConfiguration();
+    expect(calls).toBe(2);
+  });
+});

--- a/src/infrastructure/api/configuration.ts
+++ b/src/infrastructure/api/configuration.ts
@@ -1,0 +1,99 @@
+/**
+ * /configuration endpoint — TMDB image base + sizes, cached forever.
+ *
+ * TMDB asks for `/configuration` once per application lifetime: the
+ * answer changes rarely and every image URL in the app depends on it.
+ * The module keeps a single in-flight promise that every consumer
+ * awaits, so the second caller of `getAppConfiguration` resolves
+ * instantly with the cached value instead of hitting the network.
+ *
+ * Validation runs on every read of the response — even when the
+ * promise is cached, the JSON that produced the cache was validated
+ * once on the first call, so a subsequent read just returns the
+ * already-valid domain value. The schema is the safety net if TMDB
+ * ever changes shape; breaking a field in MSW must surface a clear
+ * ZodError, not a silent wrong value.
+ *
+ * "Cached forever" here means cached for the lifetime of the
+ * application process (Vite's HMR on this file resets the module,
+ * which clears the cache). A future issue can lift it to
+ * `localStorage` behind the storage adapter, scoped by version.
+ *
+ * @see Cineteca.md — "Se pide una vez y se cachea para siempre".
+ */
+
+import { z } from 'zod';
+import { tmdbHttpClient } from '@/infrastructure/http/client';
+import type { AppConfiguration } from '@/domain/configuration/app-configuration';
+
+// Zod schema for the TMDB /configuration response. Only the fields
+// the app actually needs are extracted; `change_keys` is preserved
+// as a passthrough so the domain shape stays round-trippable.
+const imageSchema = z.object({
+  base_url: z.string(),
+  secure_base_url: z.string(),
+  poster_sizes: z.array(z.string()),
+  backdrop_sizes: z.array(z.string()),
+  profile_sizes: z.array(z.string()),
+  still_sizes: z.array(z.string()),
+  logo_sizes: z.array(z.string()),
+});
+
+const configurationResponseSchema = z.object({
+  images: imageSchema,
+  change_keys: z.array(z.string()),
+});
+
+type ConfigurationResponse = z.infer<typeof configurationResponseSchema>;
+
+function toAppConfiguration(raw: ConfigurationResponse): AppConfiguration {
+  return {
+    images: {
+      baseUrl: raw.images.base_url,
+      secureBaseUrl: raw.images.secure_base_url,
+      posterSizes: raw.images.poster_sizes,
+      backdropSizes: raw.images.backdrop_sizes,
+      profileSizes: raw.images.profile_sizes,
+      stillSizes: raw.images.still_sizes,
+      logoSizes: raw.images.logo_sizes,
+    },
+    changeKeys: raw.change_keys,
+  };
+}
+
+// The cache: a single in-flight promise shared by every caller.
+// Created lazily so a test that never asks for configuration never
+// hits the network.
+let cached: Promise<AppConfiguration> | undefined;
+
+function fetchAndParse(): Promise<AppConfiguration> {
+  return tmdbHttpClient
+    .get<unknown>('/3/configuration')
+    .then((data) => configurationResponseSchema.parse(data))
+    .then(toAppConfiguration);
+}
+
+/**
+ * Returns the application configuration. Cached forever on first
+ * successful read; subsequent calls return the same promise so the
+ * network is hit once per app lifetime.
+ *
+ * Throws a ZodError if TMDB returns a response that no longer
+ * matches the expected shape. Errors raised by the HTTP client
+ * (rate limits, network failures) propagate unchanged as
+ * `TmdbHttpError`.
+ */
+export function getAppConfiguration(): Promise<AppConfiguration> {
+  cached ??= fetchAndParse();
+  return cached;
+}
+
+/**
+ * Test-only: drop the cached promise so the next call re-fetches
+ * and re-validates. Exported only because integration tests need a
+ * hook to reset state between scenarios; production code never
+ * calls it.
+ */
+export function __resetConfigurationCacheForTests(): void {
+  cached = undefined;
+}

--- a/src/infrastructure/api/discover.spec.ts
+++ b/src/infrastructure/api/discover.spec.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+const sampleSummary = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: 'Inception',
+  overview: 'A thief who steals corporate secrets.',
+  poster_path: '/poster.jpg',
+  backdrop_path: '/backdrop.jpg',
+  release_date: '2010-07-16',
+  vote_average: 8.4,
+  vote_count: 30_000,
+  genre_ids: [28, 12],
+  ...overrides,
+});
+
+describe('infrastructure/api/discover', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('returns the empty paginated shape when no filter matches', async () => {
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, () =>
+        HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 }),
+      ),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    const result = await discoverMovies();
+    expect(result).toEqual({ page: 1, results: [], totalPages: 0, totalResults: 0 });
+  });
+
+  it('translates every raw result into a domain MovieSummary (no TMDB JSON leaks)', async () => {
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [
+            sampleSummary({ id: 1 }),
+            sampleSummary({
+              id: 2,
+              title: 'The Matrix',
+              release_date: '1999-03-31',
+              poster_path: null,
+              backdrop_path: null,
+              vote_average: 8.7,
+              vote_count: 25_000,
+              genre_ids: [28, 878],
+            }),
+          ],
+          total_pages: 1,
+          total_results: 2,
+        }),
+      ),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    const result = await discoverMovies();
+    expect(result.results).toHaveLength(2);
+    const first = result.results[0];
+    const second = result.results[1];
+    expect(first?.title).toBe('Inception');
+    expect(second?.title).toBe('The Matrix');
+    expect(second?.posterPath).toEqual({ kind: 'absent' });
+    expect(result.totalPages).toBe(1);
+    expect(result.totalResults).toBe(2);
+  });
+
+  it('passes only the set filters as query parameters', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 });
+      }),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    await discoverMovies({
+      genreIds: [28, 12],
+      primaryReleaseYear: 2024,
+      minVoteAverage: 7,
+      minVoteCount: 200,
+      sortBy: 'vote_average.desc',
+      page: 2,
+      includeAdult: false,
+    });
+
+    const url = assertedUrl(requestedUrl);
+    expect(url.searchParams.get('with_genres')).toBe('28,12');
+    expect(url.searchParams.get('primary_release_year')).toBe('2024');
+    expect(url.searchParams.get('vote_average.gte')).toBe('7');
+    expect(url.searchParams.get('vote_count.gte')).toBe('200');
+    expect(url.searchParams.get('sort_by')).toBe('vote_average.desc');
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('include_adult')).toBe('false');
+  });
+
+  it('omits query parameters that were not set', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 });
+      }),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    await discoverMovies();
+
+    const url = assertedUrl(requestedUrl);
+    expect([...url.searchParams.keys()]).toEqual([]);
+  });
+
+  it('classifies the released/unreleased boundary via the shared mapper', async () => {
+    // The boundary logic lives in `toMovieSummary`; pin "now" so
+    // the assertion is deterministic at any wall-clock time.
+    const futureRaw = sampleSummary({ id: 1, release_date: '2099-12-31' });
+    const pastRaw = sampleSummary({ id: 2, release_date: '1999-03-31' });
+    const pinnedNow = new Date('2024-01-01T00:00:00Z');
+
+    const { toMovieSummary } = await import('./_shared');
+    expect(toMovieSummary(futureRaw, pinnedNow).state.kind).toBe('unreleased');
+    expect(toMovieSummary(pastRaw, pinnedNow).state.kind).toBe('released');
+  });
+
+  it('throws when a result misses a required field', async () => {
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [{ id: 1, title: 'Broken' }],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    await expect(discoverMovies()).rejects.toThrow();
+  });
+
+  it('propagates HTTP errors as TmdbHttpError (e.g. invalid page)', async () => {
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, () =>
+        HttpResponse.json({ status_code: 22, status_message: 'Invalid page.' }, { status: 400 }),
+      ),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    await expect(discoverMovies()).rejects.toMatchObject({
+      detail: { kind: 'invalidPage' },
+    });
+  });
+});
+
+function assertedUrl(value: URL | null): URL {
+  if (value === null) {
+    throw new Error('expected the handler to have captured a request URL');
+  }
+  return value;
+}

--- a/src/infrastructure/api/discover.ts
+++ b/src/infrastructure/api/discover.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { tmdbHttpClient } from '@/infrastructure/http/client';
+import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { type PaginatedList } from '@/domain/movie/paginated';
+
+/**
+ * TMDB documented sort orders. The filter UI exposes a subset;
+ * passing an unsupported string here returns the default
+ * (`popularity.desc`) on TMDB's side, but the module sends
+ * whatever the caller asks for — the schema for filters is the
+ * boundary, not TMDB's.
+ */
+export type DiscoverSortOption =
+  | 'popularity.asc'
+  | 'popularity.desc'
+  | 'release_date.asc'
+  | 'release_date.desc'
+  | 'revenue.asc'
+  | 'revenue.desc'
+  | 'primary_release_date.asc'
+  | 'primary_release_date.desc'
+  | 'vote_average.asc'
+  | 'vote_average.desc'
+  | 'vote_count.asc'
+  | 'vote_count.desc';
+
+export interface DiscoverFilters {
+  /** Comma-separated list of TMDB genre ids, e.g. `[28, 12]`. */
+  readonly genreIds?: readonly number[];
+  /** Filter by primary release year (e.g. `2024`). */
+  readonly primaryReleaseYear?: number;
+  /** Minimum `vote_average` (e.g. `7`). */
+  readonly minVoteAverage?: number;
+  /** Minimum `vote_count` for the rating to count (e.g. `100`). */
+  readonly minVoteCount?: number;
+  /** Sort order (default `popularity.desc` on the server). */
+  readonly sortBy?: DiscoverSortOption;
+  /** Page number, 1-indexed (TMDB caps at 500). */
+  readonly page?: number;
+  /** Include adult titles in the result (default false on the server). */
+  readonly includeAdult?: boolean;
+}
+
+const discoverResponseSchema = z.object({
+  page: z.number(),
+  results: z.array(tmdbMovieSummarySchema),
+  total_pages: z.number(),
+  total_results: z.number(),
+});
+
+type DiscoverResponse = z.infer<typeof discoverResponseSchema>;
+
+function toQueryParams(filters: DiscoverFilters): Record<string, string | number | boolean> {
+  // Spread construction keeps every key a literal that the linter
+  // accepts as dot-notation friendly while keeping the param object
+  // sparse (unset filters are not sent).
+  return {
+    ...(filters.genreIds && filters.genreIds.length > 0
+      ? { with_genres: filters.genreIds.join(',') }
+      : {}),
+    ...(filters.primaryReleaseYear !== undefined
+      ? { primary_release_year: filters.primaryReleaseYear }
+      : {}),
+    ...(filters.minVoteAverage !== undefined ? { 'vote_average.gte': filters.minVoteAverage } : {}),
+    ...(filters.minVoteCount !== undefined ? { 'vote_count.gte': filters.minVoteCount } : {}),
+    ...(filters.sortBy !== undefined ? { sort_by: filters.sortBy } : {}),
+    ...(filters.page !== undefined ? { page: filters.page } : {}),
+    ...(filters.includeAdult !== undefined ? { include_adult: filters.includeAdult } : {}),
+  };
+}
+
+function toPaginatedMovies(
+  raw: DiscoverResponse,
+  now: Date = new Date(),
+): PaginatedList<MovieSummary> {
+  return {
+    page: raw.page,
+    results: raw.results.map((m) => toMovieSummary(m, now)),
+    totalPages: raw.total_pages,
+    totalResults: raw.total_results,
+  };
+}
+
+/**
+ * Discover movies matching the given filters. Returns a paginated
+ * domain list — `results` are `MovieSummary` objects, not raw TMDB
+ * JSON. Each `result` is validated with the shared schema, so a
+ * broken field in the response surfaces a localized `ZodError`.
+ */
+export function discoverMovies(
+  filters: DiscoverFilters = {},
+): Promise<PaginatedList<MovieSummary>> {
+  const params = toQueryParams(filters);
+  return tmdbHttpClient
+    .get<unknown>('/3/discover/movie', { params })
+    .then((data) => discoverResponseSchema.parse(data))
+    .then((parsed) => toPaginatedMovies(parsed));
+}

--- a/src/infrastructure/api/genres.spec.ts
+++ b/src/infrastructure/api/genres.spec.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+describe('infrastructure/api/genres', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('maps each TMDB genre into a domain Genre', async () => {
+    server.use(
+      http.get(`${BASE}/3/genre/movie/list`, () =>
+        HttpResponse.json({
+          genres: [
+            { id: 28, name: 'Action' },
+            { id: 12, name: 'Adventure' },
+            { id: 16, name: 'Animation' },
+          ],
+        }),
+      ),
+    );
+
+    const { getMovieGenres } = await import('./genres');
+    const genres = await getMovieGenres();
+
+    expect(genres).toEqual([
+      { id: 28, name: 'Action' },
+      { id: 12, name: 'Adventure' },
+      { id: 16, name: 'Animation' },
+    ]);
+  });
+
+  it('returns an empty list when TMDB has no genres (empty catalogue)', async () => {
+    server.use(http.get(`${BASE}/3/genre/movie/list`, () => HttpResponse.json({ genres: [] })));
+
+    const { getMovieGenres } = await import('./genres');
+    const genres = await getMovieGenres();
+    expect(genres).toEqual([]);
+  });
+
+  it('throws when a genre entry is missing the name field', async () => {
+    server.use(
+      http.get(`${BASE}/3/genre/movie/list`, () => HttpResponse.json({ genres: [{ id: 28 }] })),
+    );
+
+    const { getMovieGenres } = await import('./genres');
+    await expect(getMovieGenres()).rejects.toThrow();
+  });
+
+  it('propagates HTTP errors as TmdbHttpError so the UI can match on the kind', async () => {
+    server.use(
+      http.get(`${BASE}/3/genre/movie/list`, () =>
+        HttpResponse.json({ status_code: 7, status_message: 'Invalid API key.' }, { status: 401 }),
+      ),
+    );
+
+    const { getMovieGenres } = await import('./genres');
+    await expect(getMovieGenres()).rejects.toMatchObject({
+      detail: { kind: 'invalidApiKey' },
+    });
+  });
+});

--- a/src/infrastructure/api/genres.ts
+++ b/src/infrastructure/api/genres.ts
@@ -1,0 +1,42 @@
+/**
+ * /genre/movie/list endpoint — the catalogue of movie genres for filters.
+ *
+ * Translates TMDB's `{ genres: [{ id, name }, …] }` into a typed
+ * domain `Genre[]`. The list is small enough that the API call
+ * happens at most once per filter screen; the UI is expected to
+ * wrap it in the TanStack Query cache (this module has no opinion
+ * on caching — that lives in the application layer).
+ *
+ * @see Cineteca.md — "Catálogo de géneros para los filtros".
+ */
+
+import { z } from 'zod';
+import { tmdbHttpClient } from '@/infrastructure/http/client';
+import type { Genre } from '@/domain/movie/genre';
+
+const genreSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+const genresResponseSchema = z.object({
+  genres: z.array(genreSchema),
+});
+
+type GenresResponse = z.infer<typeof genresResponseSchema>;
+
+function toGenres(raw: GenresResponse): readonly Genre[] {
+  return raw.genres.map((g) => ({ id: g.id, name: g.name }));
+}
+
+/**
+ * Fetches the movie genres from TMDB and returns them as domain
+ * `Genre` objects. The list is unordered by TMDB's contract; the
+ * UI is responsible for sorting and translation.
+ */
+export function getMovieGenres(): Promise<readonly Genre[]> {
+  return tmdbHttpClient
+    .get<unknown>('/3/genre/movie/list')
+    .then((data) => genresResponseSchema.parse(data))
+    .then(toGenres);
+}

--- a/src/infrastructure/api/index.ts
+++ b/src/infrastructure/api/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Public API surface for `src/infrastructure/api/`.
+ *
+ * Re-exports the seven endpoint modules the rest of the app
+ * consumes (`configuration`, `genres`, `discover`, `search`,
+ * `movie`, `recommendations`, `trending`) and nothing else. The
+ * raw-schema / mapper helpers (`./_shared`) are internal and not
+ * re-exported — domain types live in `src/domain/**` and should
+ * be imported from there.
+ *
+ * @see docs/architecture.md — "Where does this file go?".
+ */
+
+export { getAppConfiguration, __resetConfigurationCacheForTests } from './configuration';
+export { getMovieGenres } from './genres';
+export { discoverMovies, type DiscoverFilters, type DiscoverSortOption } from './discover';
+export { searchMovies, type SearchParams } from './search';
+export { getMovieDetail, type MovieDetailParams } from './movie';
+export { getMovieRecommendations, type MovieRecommendationsParams } from './recommendations';
+export { getTrendingMovies, type TrendingParams, type TrendingTimeWindow } from './trending';

--- a/src/infrastructure/api/movie.spec.ts
+++ b/src/infrastructure/api/movie.spec.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+const detailFixture = {
+  id: 27205,
+  title: 'Inception',
+  overview: 'A thief who steals corporate secrets.',
+  poster_path: '/poster.jpg',
+  backdrop_path: '/backdrop.jpg',
+  release_date: '2010-07-16',
+  vote_average: 8.4,
+  vote_count: 30_000,
+  genre_ids: [28, 12],
+  tagline: 'Your mind is the scene of the crime.',
+  runtime: 148,
+  genres: [
+    { id: 28, name: 'Action' },
+    { id: 12, name: 'Adventure' },
+  ],
+  budget: 160_000_000,
+  revenue: 836_800_000,
+};
+
+const detailWithAppendages = {
+  ...detailFixture,
+  credits: {
+    cast: [
+      {
+        id: 6193,
+        name: 'Leonardo DiCaprio',
+        character: 'Dom Cobb',
+        profile_path: '/13WoN0MpiLF8GTIRojnBYSqAaXh.jpg',
+      },
+    ],
+  },
+  videos: {
+    results: [
+      {
+        id: '5e2c1c0e3f9a4b0007c7e2b1',
+        key: 'YoHD9XEInc0',
+        site: 'YouTube',
+        type: 'Trailer',
+        name: 'Inception - Trailer',
+      },
+    ],
+  },
+};
+
+describe('infrastructure/api/movie', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('fetches the detail and maps the basic fields to MovieDetail', async () => {
+    server.use(http.get(`${BASE}/3/movie/27205`, () => HttpResponse.json(detailFixture)));
+
+    const { getMovieDetail } = await import('./movie');
+    const detail = await getMovieDetail({ id: 27205 });
+
+    expect(detail.id).toBe(27205);
+    expect(detail.title).toBe('Inception');
+    expect(detail.tagline).toEqual({
+      kind: 'present',
+      value: 'Your mind is the scene of the crime.',
+    });
+    expect(detail.runtime).toEqual({ kind: 'present', value: 148 });
+    expect(detail.genres).toEqual([
+      { id: 28, name: 'Action' },
+      { id: 12, name: 'Adventure' },
+    ]);
+    // Without the append flag, cast and trailers are absent.
+    expect(detail.cast.kind).toBe('absent');
+    expect(detail.trailers.kind).toBe('absent');
+  });
+
+  it('translates budget and revenue to Money integers (smallest unit)', async () => {
+    server.use(http.get(`${BASE}/3/movie/27205`, () => HttpResponse.json(detailFixture)));
+
+    const { getMovieDetail } = await import('./movie');
+    const detail = await getMovieDetail({ id: 27205 });
+
+    expect(detail.budget).toEqual({
+      kind: 'present',
+      value: { amount: 16_000_000_000, currency: 'USD' },
+    });
+    expect(detail.revenue).toEqual({
+      kind: 'present',
+      value: { amount: 83_680_000_000, currency: 'USD' },
+    });
+  });
+
+  it('translates 0 / null budget to NoData.absent — never "zero dollars"', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/27205`, () =>
+        HttpResponse.json({
+          ...detailFixture,
+          budget: 0,
+          revenue: 0,
+          runtime: 0,
+          tagline: '',
+        }),
+      ),
+    );
+
+    const { getMovieDetail } = await import('./movie');
+    const detail = await getMovieDetail({ id: 27205 });
+
+    expect(detail.budget.kind).toBe('absent');
+    expect(detail.revenue.kind).toBe('absent');
+    expect(detail.runtime.kind).toBe('absent');
+    expect(detail.tagline.kind).toBe('absent');
+  });
+
+  it('uses append_to_response=credits,videos when asked, returning cast and trailers as present', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/movie/27205`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json(detailWithAppendages);
+      }),
+    );
+
+    const { getMovieDetail } = await import('./movie');
+    const detail = await getMovieDetail({ id: 27205, appendCastAndTrailers: true });
+
+    const url = assertedUrl(requestedUrl);
+    expect(url.searchParams.get('append_to_response')).toBe('credits,videos');
+    expect(detail.cast).toEqual({
+      kind: 'present',
+      value: [
+        {
+          id: 6193,
+          name: 'Leonardo DiCaprio',
+          character: { kind: 'present', value: 'Dom Cobb' },
+          profilePath: { kind: 'present', value: '/13WoN0MpiLF8GTIRojnBYSqAaXh.jpg' },
+        },
+      ],
+    });
+    expect(detail.trailers).toEqual({
+      kind: 'present',
+      value: [
+        {
+          id: '5e2c1c0e3f9a4b0007c7e2b1',
+          key: 'YoHD9XEInc0',
+          site: 'YouTube',
+          type: 'Trailer',
+          name: 'Inception - Trailer',
+        },
+      ],
+    });
+  });
+
+  it('handles a detail with one appendage but not the other', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/27205`, () =>
+        HttpResponse.json({
+          ...detailFixture,
+          credits: { cast: [] },
+          // `videos` omitted: TMDB chooses not to include it here
+          // sometimes; the mapper must leave trailers absent.
+        }),
+      ),
+    );
+
+    const { getMovieDetail } = await import('./movie');
+    const detail = await getMovieDetail({ id: 27205, appendCastAndTrailers: true });
+
+    expect(detail.cast).toEqual({ kind: 'present', value: [] });
+    expect(detail.trailers.kind).toBe('absent');
+  });
+
+  it('throws when a required field is missing', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/27205`, () =>
+        HttpResponse.json({
+          id: 27205,
+          title: 'No genres here',
+          overview: '',
+          poster_path: null,
+          backdrop_path: null,
+          release_date: '',
+          vote_average: 0,
+          vote_count: 0,
+          tagline: '',
+          runtime: null,
+          genres: [],
+          budget: 0,
+          revenue: 0,
+          genre_ids: [],
+        }),
+      ),
+    );
+
+    const { getMovieDetail } = await import('./movie');
+    // The mapper expects `appendages` not to break validation;
+    // since `credits`/`videos` are absent, they default to undefined
+    // and the optional appendage branches pass. But the missing
+    // appendages block itself (no `credits` or `videos` keys) means
+    // the schema's `nullish` rule applies; this is a passing case.
+    // To exercise a real schema failure, override the handler with
+    // an explicit broken field instead.
+    void (await getMovieDetail({ id: 27205 }));
+    await expect((await import('./movie')).getMovieDetail({ id: 27205 })).resolves.toBeDefined();
+
+    server.resetHandlers();
+    server.use(
+      http.get(`${BASE}/3/movie/27205`, () =>
+        HttpResponse.json({ id: 27205, title: 'Oops' /* boom */ }),
+      ),
+    );
+    vi.resetModules();
+    const { getMovieDetail: getMovieDetailAgain } = await import('./movie');
+    await expect(getMovieDetailAgain({ id: 27205 })).rejects.toThrow();
+  });
+
+  it('propagates TMDB code 34 (not found) as notFound through the HTTP layer', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/999`, () =>
+        HttpResponse.json({ status_code: 34, status_message: 'Not found.' }, { status: 404 }),
+      ),
+    );
+
+    const { getMovieDetail } = await import('./movie');
+    await expect(getMovieDetail({ id: 999 })).rejects.toMatchObject({
+      detail: { kind: 'notFound' },
+    });
+  });
+});
+
+function assertedUrl(value: URL | null): URL {
+  if (value === null) {
+    throw new Error('expected the handler to have captured a request URL');
+  }
+  return value;
+}

--- a/src/infrastructure/api/movie.ts
+++ b/src/infrastructure/api/movie.ts
@@ -1,0 +1,33 @@
+import { tmdbHttpClient } from '@/infrastructure/http/client';
+import { toMovieDetail } from './_shared';
+import { type MovieDetail } from '@/domain/movie/movie-detail';
+
+export interface MovieDetailParams {
+  readonly id: number;
+  /**
+   * When `true`, the request uses
+   * `?append_to_response=credits,videos` and the returned
+   * `MovieDetail.cast` and `MovieDetail.trailers` are `present`.
+   * When `false` (or omitted), they are `absent`. Defaults to
+   * `false` to keep tiny detail fetches (e.g. for previews) cheap.
+   */
+  readonly appendCastAndTrailers?: boolean;
+}
+
+/**
+ * Fetches a single movie's detail page. Validates the response
+ * with the shared detail schema (including any appendage blocks)
+ * and returns a domain `MovieDetail`.
+ */
+export function getMovieDetail(params: MovieDetailParams): Promise<MovieDetail> {
+  const append = params.appendCastAndTrailers === true ? 'credits,videos' : undefined;
+  const query: Record<string, string> = {
+    ...(append !== undefined ? { append_to_response: append } : {}),
+  };
+  return tmdbHttpClient
+    .get<unknown>(
+      `/3/movie/${String(params.id)}`,
+      Object.keys(query).length > 0 ? { params: query } : undefined,
+    )
+    .then((data) => toMovieDetail(data));
+}

--- a/src/infrastructure/api/recommendations.spec.ts
+++ b/src/infrastructure/api/recommendations.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+const summary = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: 'The Dark Knight',
+  overview: 'Batman raises the stakes.',
+  poster_path: '/tdk.jpg',
+  backdrop_path: null,
+  release_date: '2008-07-16',
+  vote_average: 9.0,
+  vote_count: 30_000,
+  genre_ids: [28, 80],
+  ...overrides,
+});
+
+describe('infrastructure/api/recommendations', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('hits /movie/{id}/recommendations and returns the mapped list', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/27205/recommendations`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [summary({ id: 155 }), summary({ id: 49026 })],
+          total_pages: 1,
+          total_results: 2,
+        }),
+      ),
+    );
+
+    const { getMovieRecommendations } = await import('./recommendations');
+    const result = await getMovieRecommendations({ id: 27205 });
+
+    expect(result.results.map((m) => m.id)).toEqual([155, 49026]);
+    expect(result.totalResults).toBe(2);
+  });
+
+  it('forwards the page query parameter when set', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/movie/27205/recommendations`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 2, results: [], total_pages: 5, total_results: 100 });
+      }),
+    );
+
+    const { getMovieRecommendations } = await import('./recommendations');
+    await getMovieRecommendations({ id: 27205, page: 2 });
+
+    const url = assertedUrl(requestedUrl);
+    expect(url.searchParams.get('page')).toBe('2');
+  });
+
+  it('does not include a page query parameter when omitted', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/movie/27205/recommendations`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 });
+      }),
+    );
+
+    const { getMovieRecommendations } = await import('./recommendations');
+    await getMovieRecommendations({ id: 27205 });
+
+    const url = assertedUrl(requestedUrl);
+    expect(url.searchParams.has('page')).toBe(false);
+  });
+
+  it('returns an empty results list when the movie has no recommendations', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/27205/recommendations`, () =>
+        HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 }),
+      ),
+    );
+
+    const { getMovieRecommendations } = await import('./recommendations');
+    const result = await getMovieRecommendations({ id: 27205 });
+    expect(result.results).toEqual([]);
+  });
+
+  it('throws when a result is missing a required field', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/27205/recommendations`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [{ id: 1 }],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+
+    const { getMovieRecommendations } = await import('./recommendations');
+    await expect(getMovieRecommendations({ id: 27205 })).rejects.toThrow();
+  });
+
+  it('propagates a notFound when the source movie id does not exist', async () => {
+    server.use(
+      http.get(`${BASE}/3/movie/999/recommendations`, () =>
+        HttpResponse.json({ status_code: 34, status_message: 'Not found.' }, { status: 404 }),
+      ),
+    );
+
+    const { getMovieRecommendations } = await import('./recommendations');
+    await expect(getMovieRecommendations({ id: 999 })).rejects.toMatchObject({
+      detail: { kind: 'notFound' },
+    });
+  });
+});
+
+function assertedUrl(value: URL | null): URL {
+  if (value === null) {
+    throw new Error('expected the handler to have captured a request URL');
+  }
+  return value;
+}

--- a/src/infrastructure/api/recommendations.ts
+++ b/src/infrastructure/api/recommendations.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { tmdbHttpClient } from '@/infrastructure/http/client';
+import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { type PaginatedList } from '@/domain/movie/paginated';
+
+export interface MovieRecommendationsParams {
+  readonly id: number;
+  readonly page?: number;
+}
+
+const recommendationsResponseSchema = z.object({
+  page: z.number(),
+  results: z.array(tmdbMovieSummarySchema),
+  total_pages: z.number(),
+  total_results: z.number(),
+});
+
+type RecommendationsResponse = z.infer<typeof recommendationsResponseSchema>;
+
+function toPaginatedMovies(
+  raw: RecommendationsResponse,
+  now: Date = new Date(),
+): PaginatedList<MovieSummary> {
+  return {
+    page: raw.page,
+    results: raw.results.map((m) => toMovieSummary(m, now)),
+    totalPages: raw.total_pages,
+    totalResults: raw.total_results,
+  };
+}
+
+/**
+ * Fetches the recommendations for a movie. Returns a paginated
+ * domain list. Empty recommendations come back as `results: []`,
+ * not as an error — many movies have no recommendations and the
+ * detail screen just hides the rail.
+ */
+export function getMovieRecommendations(
+  params: MovieRecommendationsParams,
+): Promise<PaginatedList<MovieSummary>> {
+  const query: Record<string, number> = {
+    ...(params.page !== undefined ? { page: params.page } : {}),
+  };
+  const config = Object.keys(query).length > 0 ? { params: query } : undefined;
+  return tmdbHttpClient
+    .get<unknown>(`/3/movie/${String(params.id)}/recommendations`, config)
+    .then((data) => recommendationsResponseSchema.parse(data))
+    .then((parsed) => toPaginatedMovies(parsed));
+}

--- a/src/infrastructure/api/search.spec.ts
+++ b/src/infrastructure/api/search.spec.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+const hit = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: 'The Lord of the Rings',
+  overview: 'A meek Hobbit and eight companions set out on a journey.',
+  poster_path: '/lotr.jpg',
+  backdrop_path: null,
+  release_date: '2001-12-18',
+  vote_average: 8.4,
+  vote_count: 20_000,
+  genre_ids: [12, 14],
+  ...overrides,
+});
+
+describe('infrastructure/api/search', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('forwards the query as a query-string parameter and returns domain results', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/search/movie`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({
+          page: 1,
+          results: [hit()],
+          total_pages: 1,
+          total_results: 1,
+        });
+      }),
+    );
+
+    const { searchMovies } = await import('./search');
+    const result = await searchMovies({ query: 'lord of the rings' });
+
+    const url = assertedUrl(requestedUrl);
+    expect(url.searchParams.get('query')).toBe('lord of the rings');
+    expect(result.results).toHaveLength(1);
+    const first = result.results[0];
+    expect(first?.title).toBe('The Lord of the Rings');
+    expect(first?.backdropPath).toEqual({ kind: 'absent' });
+  });
+
+  it('passes page, include_adult, and primary_release_year when set', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/search/movie`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 });
+      }),
+    );
+
+    const { searchMovies } = await import('./search');
+    await searchMovies({
+      query: 'matrix',
+      page: 3,
+      includeAdult: false,
+      primaryReleaseYear: 1999,
+    });
+
+    const url = assertedUrl(requestedUrl);
+    expect(url.searchParams.get('query')).toBe('matrix');
+    expect(url.searchParams.get('page')).toBe('3');
+    expect(url.searchParams.get('include_adult')).toBe('false');
+    expect(url.searchParams.get('primary_release_year')).toBe('1999');
+  });
+
+  it('returns an empty results list when nothing matches (not an error)', async () => {
+    server.use(
+      http.get(`${BASE}/3/search/movie`, () =>
+        HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 }),
+      ),
+    );
+
+    const { searchMovies } = await import('./search');
+    const result = await searchMovies({ query: 'zzzznothingmatchesthisstringzzzz' });
+    expect(result.results).toEqual([]);
+    expect(result.totalResults).toBe(0);
+  });
+
+  it('throws when a result is missing a required field', async () => {
+    server.use(
+      http.get(`${BASE}/3/search/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [{ id: 1, title: 'No overview here' }],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+
+    const { searchMovies } = await import('./search');
+    await expect(searchMovies({ query: 'q' })).rejects.toThrow();
+  });
+
+  it('propagates HTTP errors as TmdbHttpError', async () => {
+    server.use(
+      http.get(`${BASE}/3/search/movie`, () =>
+        HttpResponse.json({ status_code: 22, status_message: 'Invalid page.' }, { status: 400 }),
+      ),
+    );
+
+    const { searchMovies } = await import('./search');
+    await expect(searchMovies({ query: 'q' })).rejects.toMatchObject({
+      detail: { kind: 'invalidPage' },
+    });
+  });
+});
+
+function assertedUrl(value: URL | null): URL {
+  if (value === null) {
+    throw new Error('expected the handler to have captured a request URL');
+  }
+  return value;
+}

--- a/src/infrastructure/api/search.ts
+++ b/src/infrastructure/api/search.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { tmdbHttpClient } from '@/infrastructure/http/client';
+import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { type PaginatedList } from '@/domain/movie/paginated';
+
+export interface SearchParams {
+  /** Free-text query. TMDB returns HTTP 400 if it is missing. */
+  readonly query: string;
+  /** Page number, 1-indexed (TMDB caps at 500). */
+  readonly page?: number;
+  /** Include adult titles. Default `false` on the server. */
+  readonly includeAdult?: boolean;
+  /** Restrict the search to a specific primary release year. */
+  readonly primaryReleaseYear?: number;
+}
+
+const searchResponseSchema = z.object({
+  page: z.number(),
+  results: z.array(tmdbMovieSummarySchema),
+  total_pages: z.number(),
+  total_results: z.number(),
+});
+
+type SearchResponse = z.infer<typeof searchResponseSchema>;
+
+function toQueryParams(params: SearchParams): Record<string, string | number | boolean> {
+  return {
+    query: params.query,
+    ...(params.page !== undefined ? { page: params.page } : {}),
+    ...(params.includeAdult !== undefined ? { include_adult: params.includeAdult } : {}),
+    ...(params.primaryReleaseYear !== undefined
+      ? { primary_release_year: params.primaryReleaseYear }
+      : {}),
+  };
+}
+
+function toPaginatedMovies(
+  raw: SearchResponse,
+  now: Date = new Date(),
+): PaginatedList<MovieSummary> {
+  return {
+    page: raw.page,
+    results: raw.results.map((m) => toMovieSummary(m, now)),
+    totalPages: raw.total_pages,
+    totalResults: raw.total_results,
+  };
+}
+
+/**
+ * Search movies by free-text `query`. Returns a paginated domain
+ * list; each result is a validated `MovieSummary` (no raw TMDB
+ * JSON). Empty results come back as an empty `results` array,
+ * not as an error — searching for nothing matched is a normal
+ * "empty by filter" state, not a failure.
+ */
+export function searchMovies(params: SearchParams): Promise<PaginatedList<MovieSummary>> {
+  const query = toQueryParams(params);
+  return tmdbHttpClient
+    .get<unknown>('/3/search/movie', { params: query })
+    .then((data) => searchResponseSchema.parse(data))
+    .then((parsed) => toPaginatedMovies(parsed));
+}

--- a/src/infrastructure/api/trending.spec.ts
+++ b/src/infrastructure/api/trending.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+
+const BASE = 'https://api.tmdb.test';
+const TOKEN = 'a'.repeat(64);
+
+const summary = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: 'Dune: Part Two',
+  overview: 'Paul Atreides unites with the Fremen.',
+  poster_path: '/dune2.jpg',
+  backdrop_path: null,
+  release_date: '2024-03-01',
+  vote_average: 8.5,
+  vote_count: 4_000,
+  genre_ids: [878, 12],
+  ...overrides,
+});
+
+describe('infrastructure/api/trending', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', TOKEN);
+    vi.stubEnv('VITE_TMDB_API_BASE', BASE);
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('hits /trending/movie/week by default and returns the domain list', async () => {
+    server.use(
+      http.get(`${BASE}/3/trending/movie/week`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [summary()],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+
+    const { getTrendingMovies } = await import('./trending');
+    const result = await getTrendingMovies({ timeWindow: 'week' });
+
+    expect(result.results[0]?.title).toBe('Dune: Part Two');
+    expect(result.totalResults).toBe(1);
+  });
+
+  it('routes to /trending/movie/day when the day window is requested', async () => {
+    let requestedPath: string | null = null;
+    server.use(
+      http.get(`${BASE}/3/trending/movie/day`, ({ request }) => {
+        requestedPath = new URL(request.url).pathname;
+        return HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 });
+      }),
+    );
+
+    const { getTrendingMovies } = await import('./trending');
+    await getTrendingMovies({ timeWindow: 'day' });
+
+    expect(requestedPath).toBe('/3/trending/movie/day');
+  });
+
+  it('forwards optional page and include_adult parameters', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/trending/movie/week`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 2, results: [], total_pages: 10, total_results: 200 });
+      }),
+    );
+
+    const { getTrendingMovies } = await import('./trending');
+    await getTrendingMovies({ timeWindow: 'week', page: 2, includeAdult: false });
+
+    const url = assertedUrl(requestedUrl);
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('include_adult')).toBe('false');
+  });
+
+  it('returns an empty list when the response has no results', async () => {
+    server.use(
+      http.get(`${BASE}/3/trending/movie/week`, () =>
+        HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 }),
+      ),
+    );
+
+    const { getTrendingMovies } = await import('./trending');
+    const result = await getTrendingMovies({ timeWindow: 'week' });
+    expect(result.results).toEqual([]);
+  });
+
+  it('throws when a result is missing a required field', async () => {
+    server.use(
+      http.get(`${BASE}/3/trending/movie/week`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [{ id: 1 }],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+
+    const { getTrendingMovies } = await import('./trending');
+    await expect(getTrendingMovies({ timeWindow: 'week' })).rejects.toThrow();
+  });
+
+  it('propagates HTTP errors as TmdbHttpError', async () => {
+    server.use(
+      http.get(`${BASE}/3/trending/movie/week`, () =>
+        HttpResponse.json({ status_code: 7, status_message: 'Invalid API key.' }, { status: 401 }),
+      ),
+    );
+
+    const { getTrendingMovies } = await import('./trending');
+    await expect(getTrendingMovies({ timeWindow: 'week' })).rejects.toMatchObject({
+      detail: { kind: 'invalidApiKey' },
+    });
+  });
+});
+
+function assertedUrl(value: URL | null): URL {
+  if (value === null) {
+    throw new Error('expected the handler to have captured a request URL');
+  }
+  return value;
+}

--- a/src/infrastructure/api/trending.ts
+++ b/src/infrastructure/api/trending.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import { tmdbHttpClient } from '@/infrastructure/http/client';
+import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { type PaginatedList } from '@/domain/movie/paginated';
+
+export type TrendingTimeWindow = 'day' | 'week';
+
+export interface TrendingParams {
+  readonly timeWindow: TrendingTimeWindow;
+  readonly page?: number;
+  /** Include adult titles in the result (default false on the server). */
+  readonly includeAdult?: boolean;
+}
+
+const trendingResponseSchema = z.object({
+  page: z.number(),
+  results: z.array(tmdbMovieSummarySchema),
+  total_pages: z.number(),
+  total_results: z.number(),
+});
+
+type TrendingResponse = z.infer<typeof trendingResponseSchema>;
+
+function toQueryParams(params: TrendingParams): Record<string, string | number | boolean> {
+  return {
+    ...(params.page !== undefined ? { page: params.page } : {}),
+    ...(params.includeAdult !== undefined ? { include_adult: params.includeAdult } : {}),
+  };
+}
+
+function toPaginatedMovies(
+  raw: TrendingResponse,
+  now: Date = new Date(),
+): PaginatedList<MovieSummary> {
+  return {
+    page: raw.page,
+    results: raw.results.map((m) => toMovieSummary(m, now)),
+    totalPages: raw.total_pages,
+    totalResults: raw.total_results,
+  };
+}
+
+/**
+ * Fetch the trending movies for the requested time window.
+ * Returns a paginated domain list; each result is a validated
+ * `MovieSummary` (no raw TMDB JSON leaks).
+ */
+export function getTrendingMovies(params: TrendingParams): Promise<PaginatedList<MovieSummary>> {
+  return tmdbHttpClient
+    .get<unknown>(`/3/trending/movie/${params.timeWindow}`, {
+      params: toQueryParams(params),
+    })
+    .then((data) => trendingResponseSchema.parse(data))
+    .then((parsed) => toPaginatedMovies(parsed));
+}

--- a/src/test/msw/tmdb-handlers.spec.ts
+++ b/src/test/msw/tmdb-handlers.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Sanity test for the shared TMDB MSW handlers.
+ *
+ * The per-endpoint spec files register their own handlers, so the
+ * shared ones are exercised by this minimal test only — that is
+ * the whole point of having the shared file. A future integration
+ * test in `src/presentation/**` can `server.use(...tmdbHandlers)`
+ * to get real-looking data without writing fixtures from scratch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { server } from './server';
+import { tmdbHandlers } from './tmdb-handlers';
+
+describe('test/msw/tmdb-handlers', () => {
+  beforeEach(() => {
+    server.use(...tmdbHandlers);
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('responds to /3/configuration with the configuration fixture', async () => {
+    const res = await fetch('https://example.test/3/configuration');
+    const body: unknown = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      images: { secure_base_url: 'https://image.tmdb.org/t/p' },
+    });
+  });
+
+  it('responds to /3/genre/movie/list with the genre catalogue', async () => {
+    const res = await fetch('https://example.test/3/genre/movie/list');
+    const body = (await res.json()) as { genres: readonly { id: number; name: string }[] };
+    expect(body.genres.map((g) => g.id)).toContain(28);
+    expect(body.genres.map((g) => g.id)).toContain(878);
+  });
+
+  it('responds to /3/discover/movie with a paginated list', async () => {
+    const res = await fetch('https://example.test/3/discover/movie');
+    const body = (await res.json()) as { results: readonly unknown[]; total_pages: number };
+    expect(body.results).toHaveLength(1);
+    expect(body.total_pages).toBe(1);
+  });
+
+  it('responds to /3/search/movie with a paginated list', async () => {
+    const res = await fetch('https://example.test/3/search/movie?query=inception');
+    const body = (await res.json()) as { results: readonly unknown[] };
+    expect(body.results).toHaveLength(1);
+  });
+
+  it('responds to /3/movie/{id} with the detail fixture (no appendages)', async () => {
+    const res = await fetch('https://example.test/3/movie/27205');
+    const body = (await res.json()) as { id: number; tagline: string; runtime: number };
+    expect(body.id).toBe(27205);
+    expect(body.tagline).toBe('Your mind is the scene of the crime.');
+    expect(body.runtime).toBe(148);
+    // The default handler must NOT include appendage keys — the
+    // appendage fixture is opt-in via a per-test override.
+    expect('credits' in body).toBe(false);
+  });
+
+  it('responds to /3/movie/{id}/recommendations with a paginated list', async () => {
+    const res = await fetch('https://example.test/3/movie/27205/recommendations');
+    const body = (await res.json()) as { results: readonly unknown[] };
+    expect(body.results).toHaveLength(1);
+  });
+
+  it('responds to /3/trending/movie/{time_window} with a paginated list', async () => {
+    const res = await fetch('https://example.test/3/trending/movie/week');
+    const body = (await res.json()) as { results: readonly unknown[] };
+    expect(body.results).toHaveLength(1);
+  });
+});

--- a/src/test/msw/tmdb-handlers.ts
+++ b/src/test/msw/tmdb-handlers.ts
@@ -1,0 +1,167 @@
+/**
+ * TMDB MSW handlers — covers the seven endpoints the app consumes.
+ *
+ * Every test consumes a different combination of filter values,
+ * pagination, or response shape, so the per-endpoint spec files
+ * declare their own handlers with the exact fixture they need. This
+ * file is for tests that just want "any valid TMDB response" — for
+ * example, a higher-level integration test that the filter UI
+ * produces a query string and the matching list arrives at the
+ * cache. Each handler returns a realistic snapshot of the response
+ * the corresponding endpoint delivers in production.
+ *
+ * Conventions:
+ *  - All handlers are `http.*` factories; pass them to
+ *    `server.use(...handlers)` at the start of the test.
+ *  - Handler order is irrelevant: `msw` matches by HTTP method and
+ *    URL path with most-recent-wins semantics, so a test can add
+ *    `server.use(http.get('/3/configuration', customHandler))` to
+ *    swap the default for a specific shape.
+ *  - The fixtures here are a baseline, not the source of truth.
+ *    Each per-endpoint spec file owns its own fixtures.
+ *
+ * @see Cineteca.md — "El contrato con la API que consumen".
+ */
+
+import { http, HttpResponse } from 'msw';
+
+// MSW glob paths (`*/3/...`) match any base URL, so the same
+// handler works against the production TMDB base (`api.themoviedb.org`)
+// and any test base the spec files stub (`api.tmdb.test` etc.). The
+// `/3/` segment pins the API version so a future v4 stub does not
+// accidentally collide.
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+//
+// These mirror the shape TMDB actually returns. Numbers are integers;
+// strings are non-null unless TMDB uses `null` to mean "absent"; arrays
+// are returned in the order TMDB chose (popularity.desc, in practice).
+
+export const TMDB_MOVIE_SUMMARY_FIXTURE = {
+  id: 27205,
+  title: 'Inception',
+  overview: 'A thief who steals corporate secrets.',
+  poster_path: '/9gk7adHYeDvHkCSEqAvQNLV5Uge.jpg',
+  backdrop_path: '/s3TBrRGB1iav7gFOCQi3fyWlYVv.jpg',
+  release_date: '2010-07-16',
+  vote_average: 8.4,
+  vote_count: 30_000,
+  genre_ids: [28, 12, 878],
+};
+
+export const TMDB_MOVIE_DETAIL_FIXTURE = {
+  ...TMDB_MOVIE_SUMMARY_FIXTURE,
+  tagline: 'Your mind is the scene of the crime.',
+  runtime: 148,
+  genres: [
+    { id: 28, name: 'Action' },
+    { id: 12, name: 'Adventure' },
+    { id: 878, name: 'Science Fiction' },
+  ],
+  budget: 160_000_000,
+  revenue: 836_800_000,
+};
+
+export const TMDB_MOVIE_DETAIL_WITH_APPENDAGES_FIXTURE = {
+  ...TMDB_MOVIE_DETAIL_FIXTURE,
+  credits: {
+    cast: [
+      {
+        id: 6193,
+        name: 'Leonardo DiCaprio',
+        character: 'Dom Cobb',
+        profile_path: '/13WoN0MpiLF8GTIRojnBYSqAaXh.jpg',
+      },
+      {
+        id: 2405,
+        name: 'Joseph Gordon-Levitt',
+        character: 'Arthur',
+        profile_path: '/4U9G4YwTlIEbAymBaseltS38eH4.jpg',
+      },
+    ],
+  },
+  videos: {
+    results: [
+      {
+        id: '5e2c1c0e3f9a4b0007c7e2b1',
+        key: 'YoHD9XEInc0',
+        site: 'YouTube',
+        type: 'Trailer',
+        name: 'Inception - Trailer',
+      },
+    ],
+  },
+};
+
+export const TMDB_CONFIGURATION_FIXTURE = {
+  images: {
+    base_url: 'http://image.tmdb.org/t/p',
+    secure_base_url: 'https://image.tmdb.org/t/p',
+    poster_sizes: ['w92', 'w154', 'w185', 'w342', 'w500', 'w780', 'original'],
+    backdrop_sizes: ['w300', 'w780', 'w1280', 'original'],
+    profile_sizes: ['w45', 'w185', 'h632', 'original'],
+    still_sizes: ['w92', 'w185', 'w300', 'original'],
+    logo_sizes: ['w45', 'w92', 'w154', 'w185', 'w300', 'w500', 'original'],
+  },
+  change_keys: ['adult', 'air_date', 'also_known_as', 'biography', 'budget', 'cast'],
+};
+
+export const TMDB_MOVIE_GENRES_FIXTURE = {
+  genres: [
+    { id: 28, name: 'Action' },
+    { id: 12, name: 'Adventure' },
+    { id: 16, name: 'Animation' },
+    { id: 35, name: 'Comedy' },
+    { id: 80, name: 'Crime' },
+    { id: 99, name: 'Documentary' },
+    { id: 18, name: 'Drama' },
+    { id: 10751, name: 'Family' },
+    { id: 14, name: 'Fantasy' },
+    { id: 36, name: 'History' },
+    { id: 27, name: 'Horror' },
+    { id: 10402, name: 'Music' },
+    { id: 9648, name: 'Mystery' },
+    { id: 10749, name: 'Romance' },
+    { id: 878, name: 'Science Fiction' },
+    { id: 10770, name: 'TV Movie' },
+    { id: 53, name: 'Thriller' },
+    { id: 10752, name: 'War' },
+    { id: 37, name: 'Western' },
+  ],
+};
+
+const paginated = <T>(results: readonly T[], page = 1) => ({
+  page,
+  results,
+  total_pages: 1,
+  total_results: results.length,
+});
+
+// =============================================================================
+// Handlers — one per endpoint the app calls.
+// =============================================================================
+
+export const tmdbHandlers = [
+  http.get('*/3/configuration', () => HttpResponse.json(TMDB_CONFIGURATION_FIXTURE)),
+
+  http.get('*/3/genre/movie/list', () => HttpResponse.json(TMDB_MOVIE_GENRES_FIXTURE)),
+
+  http.get('*/3/discover/movie', () => HttpResponse.json(paginated([TMDB_MOVIE_SUMMARY_FIXTURE]))),
+
+  http.get('*/3/search/movie', () => HttpResponse.json(paginated([TMDB_MOVIE_SUMMARY_FIXTURE]))),
+
+  // Per-id detail: the handler does not branch on the append flag,
+  // so a test that wants the appendage keys to be present should
+  // override this handler with `server.use(...)`.
+  http.get('*/3/movie/:id', () => HttpResponse.json(TMDB_MOVIE_DETAIL_FIXTURE)),
+
+  http.get('*/3/movie/:id/recommendations', () =>
+    HttpResponse.json(paginated([TMDB_MOVIE_SUMMARY_FIXTURE])),
+  ),
+
+  http.get('*/3/trending/movie/:timeWindow', () =>
+    HttpResponse.json(paginated([TMDB_MOVIE_SUMMARY_FIXTURE])),
+  ),
+];


### PR DESCRIPTION
Seven endpoints, one module each, each typed at the boundary:

- **configuration** — image base + sizes, cached forever via a lazy in-flight promise so the network is hit once per app lifetime.
- **genres** — movie genres for filters.
- **discover** — paginated discovery with filters (genre, year, min rating, min votes, sort, page, include_adult).
- **search** — paginated text search with query, page, include_adult, primary_release_year.
- **movie** — single-movie detail; `appendCastAndTrailers` flips on `append_to_response=credits,videos` so cast and trailers come back in the same round-trip.
- **recommendations** — paginated recommendations for a movie id.
- **trending** — paginated trending for day or week.

Every response is parsed by a Zod schema before it leaves infrastructure; a broken field surfaces a `ZodError`, never a silent wrong value. TMDB's raw `poster_path:null` / `release_date:''` become explicit `NoData` or `unknown MovieState` at the edge, so the domain stays free of TMDB.

Domain additions (composed from existing primitives, no axios/React imports): `MovieSummary`, `MovieDetail`, `CastMember`, `Trailer`, `Genre`, `PaginatedList`, `AppConfiguration`, `ImageConfiguration`.

MSW handlers in `src/test/msw/tmdb-handlers.ts` cover the seven endpoints with realistic fixtures — available to any future integration test, not used by these per-endpoint specs (each one owns its own handler for shape variations).

Closes #12