### PR TITLE
feat(presentation): Explore screen with URL filters and four states

### DIFF
--- a/src/domain/configuration/image-configuration.spec.ts
+++ b/src/domain/configuration/image-configuration.spec.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import type { ImageConfiguration } from './image-configuration';
+import {
+  backdropUrl,
+  DEFAULT_BACKDROP_SIZE,
+  DEFAULT_POSTER_SIZE,
+  posterUrl,
+  type ImageConfiguration,
+} from './image-configuration';
+
+const baseConfig: ImageConfiguration = {
+  baseUrl: 'http://image.tmdb.org/t/p',
+  secureBaseUrl: 'https://image.tmdb.org/t/p',
+  posterSizes: ['w92', 'w185', 'w500'],
+  backdropSizes: ['w300', 'w780'],
+  profileSizes: ['w185'],
+  stillSizes: ['w300'],
+  logoSizes: ['w300'],
+};
 
 describe('domain/configuration/image-configuration', () => {
   it('carries the secure base and the per-type size lists', () => {
@@ -15,5 +31,65 @@ describe('domain/configuration/image-configuration', () => {
     expect(config.secureBaseUrl).toBe('https://image.tmdb.org/t/p');
     expect(config.posterSizes).toContain('w500');
     expect(config.posterSizes).toContain('original');
+  });
+});
+
+describe('posterUrl', () => {
+  it('returns null when the path is null', () => {
+    expect(posterUrl(baseConfig, null)).toBeNull();
+  });
+
+  it('returns null when the path is the empty string', () => {
+    expect(posterUrl(baseConfig, '')).toBeNull();
+  });
+
+  it('builds a URL with the requested size when available', () => {
+    expect(posterUrl(baseConfig, '/abc.jpg', 'w500')).toBe(
+      'https://image.tmdb.org/t/p/w500/abc.jpg',
+    );
+  });
+
+  it('falls back to the first configured size when the requested size is unknown', () => {
+    expect(posterUrl(baseConfig, '/abc.jpg', 'w9999')).toBe(
+      'https://image.tmdb.org/t/p/w92/abc.jpg',
+    );
+  });
+
+  it('falls back to the default size when the catalogue is empty', () => {
+    const empty: ImageConfiguration = { ...baseConfig, posterSizes: [] };
+    expect(posterUrl(empty, '/abc.jpg')).toBe(
+      `https://image.tmdb.org/t/p/${DEFAULT_POSTER_SIZE}/abc.jpg`,
+    );
+  });
+
+  it('uses the default size when none is requested', () => {
+    expect(posterUrl(baseConfig, '/abc.jpg')).toBe(
+      `https://image.tmdb.org/t/p/${DEFAULT_POSTER_SIZE}/abc.jpg`,
+    );
+  });
+});
+
+describe('backdropUrl', () => {
+  it('returns null when the path is null', () => {
+    expect(backdropUrl(baseConfig, null)).toBeNull();
+  });
+
+  it('builds a URL with the requested size when available', () => {
+    expect(backdropUrl(baseConfig, '/bd.jpg', 'w780')).toBe(
+      'https://image.tmdb.org/t/p/w780/bd.jpg',
+    );
+  });
+
+  it('falls back to the first configured size when the requested size is unknown', () => {
+    expect(backdropUrl(baseConfig, '/bd.jpg', 'w9999')).toBe(
+      'https://image.tmdb.org/t/p/w300/bd.jpg',
+    );
+  });
+
+  it('falls back to the default size when the catalogue is empty', () => {
+    const empty: ImageConfiguration = { ...baseConfig, backdropSizes: [] };
+    expect(backdropUrl(empty, '/bd.jpg')).toBe(
+      `https://image.tmdb.org/t/p/${DEFAULT_BACKDROP_SIZE}/bd.jpg`,
+    );
   });
 });

--- a/src/domain/configuration/image-configuration.ts
+++ b/src/domain/configuration/image-configuration.ts
@@ -25,3 +25,41 @@ export interface ImageConfiguration {
   readonly stillSizes: readonly string[];
   readonly logoSizes: readonly string[];
 }
+
+/** The default poster size when nothing is specified. `w185` is small
+ * enough to be a fast first paint but big enough to be recognisable. */
+export const DEFAULT_POSTER_SIZE = 'w185';
+
+/** The default backdrop size. `w780` matches TMDB's recommended size
+ * for high-density mobile and desktop cards. */
+export const DEFAULT_BACKDROP_SIZE = 'w780';
+
+/** Build the full URL for a poster, falling back to a default size
+ * when the configuration has no poster sizes (degraded path).
+ * Returns `null` when the path is absent so the caller can render a
+ * placeholder without branching on the empty-string form. */
+export function posterUrl(
+  config: ImageConfiguration,
+  path: string | null,
+  size: string = DEFAULT_POSTER_SIZE,
+): string | null {
+  if (path === null || path === '') return null;
+  const sizeToUse = config.posterSizes.includes(size)
+    ? size
+    : (config.posterSizes[0] ?? DEFAULT_POSTER_SIZE);
+  return `${config.secureBaseUrl}/${sizeToUse}${path}`;
+}
+
+/** Build the full URL for a backdrop. Same null-and-default
+ * semantics as `posterUrl`. */
+export function backdropUrl(
+  config: ImageConfiguration,
+  path: string | null,
+  size: string = DEFAULT_BACKDROP_SIZE,
+): string | null {
+  if (path === null || path === '') return null;
+  const sizeToUse = config.backdropSizes.includes(size)
+    ? size
+    : (config.backdropSizes[0] ?? DEFAULT_BACKDROP_SIZE);
+  return `${config.secureBaseUrl}/${sizeToUse}${path}`;
+}

--- a/src/presentation/components/feature/movie-card.spec.tsx
+++ b/src/presentation/components/feature/movie-card.spec.tsx
@@ -1,0 +1,103 @@
+// presentation/components/feature/movie-card.spec.tsx
+//
+// Verifies the three visual tiers (title, year, rating) and the
+// poster URL pipeline (the image-configuration domain helper does
+// the joining; this test asserts the card passes the right
+// arguments and renders the right output).
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { released, unreleased, unknownMovieState } from '@/domain/movie/movie-state';
+import { ratingReliability } from '@/domain/rating/rating-reliability';
+import { type ImageConfiguration } from '@/domain/configuration/image-configuration';
+import { MovieCard } from './movie-card';
+
+const baseConfig: ImageConfiguration = {
+  baseUrl: 'http://image.tmdb.org/t/p',
+  secureBaseUrl: 'https://image.tmdb.org/t/p',
+  posterSizes: ['w92', 'w185', 'w500'],
+  backdropSizes: ['w300', 'w780'],
+  profileSizes: ['w185'],
+  stillSizes: ['w300'],
+  logoSizes: ['w300'],
+};
+
+function makeMovie(overrides: Partial<MovieSummary> = {}): MovieSummary {
+  return {
+    id: 27205,
+    title: 'Inception',
+    overview: '',
+    posterPath: { kind: 'present', value: '/abc.jpg' },
+    backdropPath: { kind: 'absent' },
+    state: released(new Date('2010-07-16T00:00:00Z')),
+    rating: ratingReliability(30_000, 8.4),
+    genreIds: [28, 12, 878],
+    ...overrides,
+  };
+}
+
+function renderCard(movie: MovieSummary, config: ImageConfiguration | undefined = baseConfig) {
+  return render(
+    <MemoryRouter>
+      <MovieCard movie={movie} imageConfig={config} locale="en-US" />
+    </MemoryRouter>,
+  );
+}
+
+describe('MovieCard', () => {
+  it('renders the three tiers: title, year, rating', () => {
+    renderCard(makeMovie());
+
+    expect(screen.getByTestId('movie-card-title')).toHaveTextContent('Inception');
+    expect(screen.getByTestId('movie-card-year')).toHaveTextContent('2010');
+    expect(screen.getByTestId('movie-card-rating')).toHaveTextContent('8.4');
+  });
+
+  it('builds the poster URL from the image configuration', () => {
+    renderCard(makeMovie({ posterPath: { kind: 'present', value: '/abc.jpg' } }));
+
+    const imgElement = document.querySelector('img');
+    expect(imgElement).not.toBeNull();
+    expect(imgElement?.getAttribute('src')).toBe('https://image.tmdb.org/t/p/w185/abc.jpg');
+  });
+
+  it('renders the "no poster" placeholder when the path is absent', () => {
+    renderCard(makeMovie({ posterPath: { kind: 'absent' } }));
+    expect(screen.getByText(/no poster/i)).toBeInTheDocument();
+  });
+
+  it('renders the year as a placeholder dash for unknown state', () => {
+    renderCard(makeMovie({ state: unknownMovieState() }));
+    expect(screen.getByTestId('movie-card-year')).toHaveTextContent('—');
+  });
+
+  it('renders "Upcoming" for an unreleased state', () => {
+    renderCard(makeMovie({ state: unreleased(new Date('2099-12-31T00:00:00Z')) }));
+    expect(screen.getByTestId('movie-card-year')).toHaveTextContent(/upcoming/i);
+  });
+
+  it('renders the "no rating" label when the rating is unknown', () => {
+    renderCard(makeMovie({ rating: ratingReliability(0, 0) }));
+    const ratingEl = screen.getByTestId('movie-card-rating');
+    expect(ratingEl.dataset.ratingKind).toBe('unknown');
+    expect(ratingEl).toHaveTextContent(/no rating/i);
+  });
+
+  it('flags early ratings in the rating data attribute', () => {
+    renderCard(makeMovie({ rating: ratingReliability(10, 7.5) }));
+    expect(screen.getByTestId('movie-card-rating').dataset.ratingKind).toBe('early');
+  });
+
+  it('links to the movie detail page', () => {
+    renderCard(makeMovie({ id: 27205 }));
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('/movie/27205');
+  });
+
+  it('has a meaningful accessible name', () => {
+    renderCard(makeMovie({ title: 'Inception' }));
+    expect(screen.getByRole('link', { name: /inception/i })).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/feature/movie-card.tsx
+++ b/src/presentation/components/feature/movie-card.tsx
@@ -1,0 +1,168 @@
+// presentation/components/feature/movie-card.tsx — the grid card.
+//
+// Three visual tiers, top to bottom:
+//
+//   1. Title       — the bold name of the movie, clamped to two lines.
+//   2. Year        — the primary release year, or a placeholder
+//                    dash when TMDB has no date. Future iterations
+//                    may append the runtime; today's MovieSummary
+//                    does not carry one.
+//   3. Rating      — the average vote plus the vote count, or a
+//                    placeholder when the rating is unknown.
+//
+// The poster area reserves the 2:3 aspect ratio via the
+// `aspect-poster` class — the slot is sized before the image loads
+// so the grid never reflows when the bytes arrive.
+
+import type { ReactNode } from 'react';
+import { Link } from 'react-router';
+import { type ImageConfiguration, posterUrl } from '@/domain/configuration/image-configuration';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { matchMovieState } from '@/domain/movie/movie-state';
+import { matchRatingReliability } from '@/domain/rating/rating-reliability';
+import { cn } from '@/presentation/lib/cn';
+import { copy } from '@/presentation/copy/strings';
+
+export interface MovieCardProps {
+  readonly movie: MovieSummary;
+  readonly imageConfig: ImageConfiguration | undefined;
+  /** A locale used by the rating formatters. Defaults to the user's
+   *  locale so tests do not need a provider. */
+  readonly locale?: string;
+  /** Used by virtualized grids to give the cell a stable test id. */
+  readonly testId?: string;
+}
+
+function formatYear(state: MovieSummary['state']): string {
+  return matchMovieState(state, {
+    released: (date) => String(date.getUTCFullYear()),
+    unreleased: () => copy.movieCard.unreleased,
+    unknown: () => copy.movieCard.noYear,
+  });
+}
+
+function formatRating(rating: MovieSummary['rating']): {
+  label: string;
+  kind: 'consolidated' | 'early' | 'unknown';
+  value: number | null;
+  votes: number | null;
+} {
+  return matchRatingReliability(rating, {
+    consolidated: (votes, average) => ({
+      label: average.toFixed(1),
+      kind: 'consolidated' as const,
+      value: average,
+      votes,
+    }),
+    early: (votes, average) => ({
+      label: average.toFixed(1),
+      kind: 'early' as const,
+      value: average,
+      votes,
+    }),
+    unknown: () => ({
+      label: copy.movieCard.noRating,
+      kind: 'unknown' as const,
+      value: null,
+      votes: null,
+    }),
+  });
+}
+
+function formatVotes(votes: number, locale: string): string {
+  try {
+    return new Intl.NumberFormat(locale, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(votes);
+  } catch {
+    // Some jsdom test environments do not implement Intl.NumberFormat
+    // with every option. Fall back to the raw number so the test
+    // still asserts something meaningful.
+    return String(votes);
+  }
+}
+
+export function MovieCard({
+  movie,
+  imageConfig,
+  locale = 'en-US',
+  testId,
+}: MovieCardProps): ReactNode {
+  const year = formatYear(movie.state);
+  const rating = formatRating(movie.rating);
+  const poster =
+    imageConfig !== undefined
+      ? posterUrl(imageConfig, movie.posterPath.kind === 'present' ? movie.posterPath.value : null)
+      : null;
+  const yearForAria =
+    movie.state.kind === 'released' || movie.state.kind === 'unreleased' ? year : 'no year';
+  const accessibleName = copy.movieCard.accessibleName(movie.title, yearForAria, rating.label);
+  const hasPoster = poster !== null;
+  const isUpcoming = movie.state.kind === 'unreleased';
+
+  return (
+    <Link
+      to={`/movie/${String(movie.id)}`}
+      aria-label={accessibleName}
+      data-testid={testId ?? 'movie-card'}
+      data-movie-id={movie.id}
+      className={cn(
+        'group flex h-full flex-col gap-2 rounded-card border border-transparent bg-surface-raised p-3',
+        'transition-colors hover:border-brand/40 focus-visible:border-brand focus-visible:outline-none',
+      )}
+    >
+      <div className="relative aspect-poster w-full overflow-hidden rounded-card bg-surface">
+        {hasPoster ? (
+          <img
+            src={poster}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+        ) : (
+          <div
+            aria-hidden
+            className="flex h-full w-full items-center justify-center text-xs text-ink-muted"
+          >
+            {copy.movieCard.noPoster}
+          </div>
+        )}
+        {isUpcoming && (
+          <span
+            className="absolute left-2 top-2 inline-flex items-center rounded-full bg-status-unreleased/20 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-status-unreleased"
+            aria-hidden
+          >
+            {copy.movieCard.unreleased}
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <h3 className="line-clamp-2 text-sm font-semibold text-ink" data-testid="movie-card-title">
+          {movie.title}
+        </h3>
+        <p className="text-xs text-ink-muted" data-testid="movie-card-year">
+          {year}
+        </p>
+        <p
+          data-testid="movie-card-rating"
+          data-rating-kind={rating.kind}
+          className={cn(
+            'text-rating font-semibold leading-(--text-rating--line-height)',
+            rating.kind === 'consolidated' && 'text-status-released',
+            rating.kind === 'early' && 'text-status-unreleased',
+            rating.kind === 'unknown' && 'text-ink-muted',
+          )}
+        >
+          {rating.label}
+          {rating.votes !== null && (
+            <span className="ml-1 text-xs font-normal text-ink-muted">
+              ({formatVotes(rating.votes, locale)})
+            </span>
+          )}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/src/presentation/components/feature/movie-grid.spec.tsx
+++ b/src/presentation/components/feature/movie-grid.spec.tsx
@@ -1,0 +1,117 @@
+// presentation/components/feature/movie-grid.spec.tsx
+//
+// Verifies the structural contract of the grid:
+//
+//   - The grid groups movies into rows for virtualization.
+//   - The container is scrollable.
+//   - The data attributes that the virtualizer relies on (row count,
+//     column count) are present and correct.
+//   - The component does not crash on edge cases (empty list, very
+//     long list).
+//
+// jsdom does not implement real layout, so the virtualizer's
+// windowing cannot be exercised here. The virtualization behaviour
+// is owned by `@tanstack/react-virtual` and is covered by its own
+// tests; we trust it to mount only the visible rows once the scroll
+// element has a real height in the browser.
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ImageConfiguration } from '@/domain/configuration/image-configuration';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { released } from '@/domain/movie/movie-state';
+import { ratingReliability } from '@/domain/rating/rating-reliability';
+import { MovieGrid } from './movie-grid';
+
+const baseConfig: ImageConfiguration = {
+  baseUrl: 'http://image.tmdb.org/t/p',
+  secureBaseUrl: 'https://image.tmdb.org/t/p',
+  posterSizes: ['w92', 'w185', 'w500'],
+  backdropSizes: ['w300', 'w780'],
+  profileSizes: ['w185'],
+  stillSizes: ['w300'],
+  logoSizes: ['w300'],
+};
+
+function makeMovie(id: number, title: string): MovieSummary {
+  return {
+    id,
+    title,
+    overview: '',
+    posterPath: { kind: 'absent' },
+    backdropPath: { kind: 'absent' },
+    state: released(new Date('2020-01-01T00:00:00Z')),
+    rating: ratingReliability(100, 7.5),
+    genreIds: [],
+  };
+}
+
+function makeMovies(count: number): MovieSummary[] {
+  return Array.from({ length: count }, (_, i) => makeMovie(i + 1, `Movie ${String(i + 1)}`));
+}
+
+describe('MovieGrid', () => {
+  beforeEach(() => {
+    // jsdom does not implement layout. Mock the size so the
+    // ResizeObserver sees a deterministic value.
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 600,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders an empty grid when there are no movies', () => {
+    render(<MovieGrid movies={[]} imageConfig={baseConfig} locale="en-US" />);
+    const grid = screen.getByTestId('movie-grid');
+    expect(grid).toBeInTheDocument();
+    expect(grid.dataset.rowCount).toBe('0');
+  });
+
+  it('groups movies into rows for virtualization', () => {
+    const movies = makeMovies(20);
+    render(<MovieGrid movies={movies} imageConfig={baseConfig} locale="en-US" />);
+    const grid = screen.getByTestId('movie-grid');
+    // 600px client width falls into the `minWidth: 0` bucket (2 cols).
+    expect(grid.dataset.columnCount).toBe('2');
+    expect(grid.dataset.rowCount).toBe('10');
+  });
+
+  it('uses more columns on wider viewports', () => {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 1400,
+    });
+    const movies = makeMovies(30);
+    render(<MovieGrid movies={movies} imageConfig={baseConfig} locale="en-US" />);
+    const grid = screen.getByTestId('movie-grid');
+    // 1400px falls into the `minWidth: 1280` bucket (5 cols).
+    expect(grid.dataset.columnCount).toBe('5');
+    expect(grid.dataset.rowCount).toBe('6');
+  });
+
+  it('renders the container as scrollable', () => {
+    render(<MovieGrid movies={makeMovies(5)} imageConfig={baseConfig} locale="en-US" />);
+    const grid = screen.getByTestId('movie-grid');
+    expect(grid.className).toMatch(/overflow-auto/);
+  });
+
+  it('reserves the full virtual height for a long list so the scrollbar is correct', () => {
+    const movies = makeMovies(200);
+    render(
+      <MovieGrid movies={movies} imageConfig={baseConfig} locale="en-US" heightClass="h-96" />,
+    );
+    const grid = screen.getByTestId('movie-grid');
+    expect(grid.dataset.rowCount).toBe('100');
+    const inner = screen.getByTestId('movie-grid-inner');
+    // The inner spacer height must be greater than zero so the
+    // browser shows a real scrollbar; if it were 0 the virtualizer
+    // would not have a scrollable surface to drive.
+    const totalHeight = Number.parseInt(inner.style.height, 10);
+    expect(Number.isFinite(totalHeight)).toBe(true);
+    expect(totalHeight).toBeGreaterThan(0);
+  });
+});

--- a/src/presentation/components/feature/movie-grid.tsx
+++ b/src/presentation/components/feature/movie-grid.tsx
@@ -1,0 +1,144 @@
+// presentation/components/feature/movie-grid.tsx — the explore grid.
+//
+// Renders a responsive grid of MovieCards. The list can hold
+// thousands of rows (TMDB caps the catalogue at 500 pages × 20
+// results per page), so the grid is virtualized: only the visible
+// rows are mounted, and the scroll position drives which ones.
+//
+// The column count is fluid — 2 columns on mobile, 6 on wide
+// screens. The virtualizer needs a predictable row height, so the
+// component measures the container's width with a `ResizeObserver`
+// and computes the row height from the column width, the poster's
+// 2:3 aspect, and the text area below.
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { type ImageConfiguration } from '@/domain/configuration/image-configuration';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { MovieCard } from '@/presentation/components/feature/movie-card';
+import { cn } from '@/presentation/lib/cn';
+
+const GAP_PX = 16;
+/** Approximate height of the text area below the poster: two
+ *  title lines, the year, and the rating. */
+const TEXT_AREA_PX = 80;
+
+const BREAKPOINTS: readonly { readonly minWidth: number; readonly columns: number }[] = [
+  { minWidth: 1536, columns: 6 },
+  { minWidth: 1280, columns: 5 },
+  { minWidth: 1024, columns: 4 },
+  { minWidth: 768, columns: 3 },
+  { minWidth: 0, columns: 2 },
+];
+
+function columnsForWidth(width: number): number {
+  for (const bp of BREAKPOINTS) {
+    if (width >= bp.minWidth) return bp.columns;
+  }
+  return 2;
+}
+
+function rowHeightFor(width: number, columns: number): number {
+  const totalGaps = GAP_PX * (columns - 1);
+  const columnWidth = Math.max(0, (width - totalGaps) / columns);
+  const posterHeight = columnWidth * 1.5;
+  return Math.ceil(posterHeight + TEXT_AREA_PX + GAP_PX);
+}
+
+export interface MovieGridProps {
+  readonly movies: readonly MovieSummary[];
+  readonly imageConfig: ImageConfiguration | undefined;
+  readonly locale: string;
+  /** Tailwind height class for the scroll container. Defaults to a
+   *  viewport-sized scroller so a thousand-row list does not push
+   *  the filter bar off the screen. */
+  readonly heightClass?: string;
+}
+
+export function MovieGrid({
+  movies,
+  imageConfig,
+  locale,
+  heightClass = 'h-[calc(100vh-22rem)]',
+}: MovieGridProps): ReactNode {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const node = parentRef.current;
+    if (node === null) return;
+    const update = () => {
+      setWidth(node.clientWidth);
+    };
+    update();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const columns = columnsForWidth(width);
+  const rowHeight = rowHeightFor(width, columns);
+  const rows = useMemo(() => {
+    const chunked: MovieSummary[][] = [];
+    for (let i = 0; i < movies.length; i += columns) {
+      chunked.push(movies.slice(i, i + columns));
+    }
+    return chunked;
+  }, [movies, columns]);
+
+  // TanStack Virtual's `useVirtualizer()` is intentionally not memoizable.
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => rowHeight,
+    overscan: 4,
+  });
+
+  // Re-measure when the row height changes (column count changed)
+  // or after the first paint (so the virtualizer picks up the
+  // scroll element, which is null on the first render).
+  useEffect(() => {
+    virtualizer.measure();
+  }, [rowHeight, virtualizer, width]);
+
+  return (
+    <div
+      ref={parentRef}
+      data-testid="movie-grid"
+      data-row-count={rows.length}
+      data-column-count={columns}
+      className={cn('relative overflow-auto', heightClass)}
+    >
+      <div
+        style={{ height: `${String(virtualizer.getTotalSize())}px`, position: 'relative' }}
+        data-testid="movie-grid-inner"
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const row = rows[virtualRow.index];
+          if (row === undefined) return null;
+          return (
+            <div
+              key={virtualRow.key}
+              data-testid="movie-grid-row"
+              data-row-index={virtualRow.index}
+              className="absolute left-0 right-0 grid gap-4 px-0"
+              style={{
+                top: `${String(virtualRow.start)}px`,
+                height: `${String(virtualRow.size)}px`,
+                gridTemplateColumns: `repeat(${String(columns)}, minmax(0, 1fr))`,
+              }}
+            >
+              {row.map((movie) => (
+                <MovieCard key={movie.id} movie={movie} imageConfig={imageConfig} locale={locale} />
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/presentation/components/ui/empty-state.tsx
+++ b/src/presentation/components/ui/empty-state.tsx
@@ -1,0 +1,57 @@
+// presentation/components/ui/empty-state.tsx — the "nothing to show" panel.
+//
+// Used by every screen that has an empty state: the explore grid
+// when the catalogue returns no rows, the home grid when the trending
+// list is empty, and the search results when the query matches
+// nothing. The optional `action` slot covers the "clear filters"
+// button required by issue #13.
+
+import type { ReactNode } from 'react';
+import { cn } from '@/presentation/lib/cn';
+
+export interface EmptyStateAction {
+  readonly label: string;
+  readonly onClick: () => void;
+}
+
+interface EmptyStateProps {
+  readonly title: string;
+  readonly description?: string;
+  readonly action?: EmptyStateAction;
+  readonly children?: ReactNode;
+  readonly className?: string;
+}
+
+export function EmptyState({
+  title,
+  description,
+  action,
+  children,
+  className,
+}: EmptyStateProps): ReactNode {
+  return (
+    <div
+      role="status"
+      data-testid="empty-state"
+      className={cn(
+        'flex flex-col items-center gap-3 rounded-card border border-ink-muted/20 bg-surface-raised px-6 py-12 text-center',
+        className,
+      )}
+    >
+      <h2 className="text-lg font-semibold text-ink">{title}</h2>
+      {description !== undefined && (
+        <p className="max-w-sm text-sm text-ink-muted">{description}</p>
+      )}
+      {children}
+      {action !== undefined && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="mt-2 inline-flex items-center justify-center rounded-card bg-brand px-5 py-2 text-sm font-medium text-surface transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/presentation/components/ui/error-state.tsx
+++ b/src/presentation/components/ui/error-state.tsx
@@ -1,0 +1,48 @@
+// presentation/components/ui/error-state.tsx — the "we could not load
+// this" panel.
+//
+// The optional `action` slot covers the "retry" button. The `role="alert"`
+// attribute means screen readers announce the error as soon as it
+// mounts, without the user having to navigate to the message.
+
+import type { ReactNode } from 'react';
+import { cn } from '@/presentation/lib/cn';
+
+export interface ErrorStateAction {
+  readonly label: string;
+  readonly onClick: () => void;
+}
+
+interface ErrorStateProps {
+  readonly title: string;
+  readonly description?: string;
+  readonly action?: ErrorStateAction;
+  readonly className?: string;
+}
+
+export function ErrorState({ title, description, action, className }: ErrorStateProps): ReactNode {
+  return (
+    <div
+      role="alert"
+      data-testid="error-state"
+      className={cn(
+        'flex flex-col items-center gap-3 rounded-card border border-danger/40 bg-surface-raised px-6 py-12 text-center',
+        className,
+      )}
+    >
+      <h2 className="text-lg font-semibold text-ink">{title}</h2>
+      {description !== undefined && (
+        <p className="max-w-sm text-sm text-ink-muted">{description}</p>
+      )}
+      {action !== undefined && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="mt-2 inline-flex items-center justify-center rounded-card bg-brand px-5 py-2 text-sm font-medium text-surface transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/presentation/components/ui/skeleton.tsx
+++ b/src/presentation/components/ui/skeleton.tsx
@@ -1,0 +1,48 @@
+// presentation/components/ui/skeleton.tsx — the loading placeholder.
+//
+// A skeleton must occupy the same space as the final content, so the
+// grid does not jump when the data arrives. The "card" variant
+// mirrors the three-tier MovieCard: the poster area keeps the
+// 2:3 aspect ratio, and the text rows are sized to match the title
+// (two lines) and the year/rating lines.
+
+import { type HTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/presentation/lib/cn';
+
+export type SkeletonVariant = 'text' | 'poster' | 'card' | 'block';
+
+interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  readonly variant?: SkeletonVariant;
+}
+
+const BASE_CLASS = 'animate-pulse rounded-md bg-surface-raised';
+
+const VARIANT_CLASS: Record<SkeletonVariant, string> = {
+  // A single line of text. Use for one-line labels.
+  text: 'h-4 w-full',
+  // Just the 2:3 poster area. Use when the title and meta are
+  // rendered separately and we only need to mask the image.
+  poster: 'aspect-poster w-full rounded-card',
+  // The full MovieCard silhouette. Use inside the explore grid so
+  // the loading state has the same shape as the loaded state.
+  card: 'flex flex-col gap-2 rounded-card border border-transparent p-3',
+  // A generic block with a fixed height. Use for one-off sections
+  // such as the filter bar.
+  block: 'h-32 w-full',
+};
+
+export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(function Skeleton(
+  { variant = 'text', className, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      data-testid="skeleton"
+      data-variant={variant}
+      className={cn(BASE_CLASS, VARIANT_CLASS[variant], className)}
+      {...rest}
+    />
+  );
+});

--- a/src/presentation/copy/strings.ts
+++ b/src/presentation/copy/strings.ts
@@ -16,6 +16,44 @@ export const copy = {
     title: 'Trending this week',
     description: 'Movies and series trending right now, straight from the TMDB catalog.',
   },
+  explore: {
+    title: 'Explore movies',
+    description: 'Filter the TMDB catalog by genre, year, minimum rating, and sort order.',
+    filters: {
+      title: 'Filters',
+      genre: 'Genre',
+      year: 'Year',
+      minRating: 'Minimum rating',
+      minVotes: 'Minimum votes',
+      sortBy: 'Sort by',
+      clear: 'Clear filters',
+      any: 'Any',
+    },
+    sortOptions: {
+      popularityDesc: 'Most popular',
+      popularityAsc: 'Least popular',
+      releaseDateDesc: 'Newest releases',
+      releaseDateAsc: 'Oldest releases',
+      ratingDesc: 'Highest rated',
+      ratingAsc: 'Lowest rated',
+      titleAsc: 'Title (A–Z)',
+      titleDesc: 'Title (Z–A)',
+    },
+    emptyInitial: 'No movies to show yet. Try adjusting your filters.',
+    emptyByFilter: 'No movies match these filters.',
+    clearFiltersAction: 'Clear filters',
+    loadMore: 'Load more',
+    loading: 'Loading movies…',
+    loadingAria: 'Loading explore grid',
+  },
+  movieCard: {
+    noPoster: 'No poster',
+    noYear: '—',
+    noRating: 'No rating',
+    unreleased: 'Upcoming',
+    accessibleName: (title: string, year: string, ratingLabel: string) =>
+      `${title}, ${year}, ${ratingLabel}`,
+  },
   notFound: {
     title: 'Page not found',
     description: 'The page you are looking for does not exist or has been moved.',
@@ -25,6 +63,8 @@ export const copy = {
     boundaryTitle: 'Something went wrong',
     boundaryDescription: 'An unexpected error stopped the page. You can try again.',
     retry: 'Try again',
+    title: 'Something went wrong',
+    description: 'We could not load the movies. Please try again.',
   },
   footer: {
     // Required by TMDB's terms of use. Kept verbatim across languages.

--- a/src/presentation/hooks/use-discover-movies.ts
+++ b/src/presentation/hooks/use-discover-movies.ts
@@ -1,0 +1,49 @@
+// presentation/hooks/use-discover-movies.ts — paginated discover feed.
+//
+// Each filter combination has its own query key, so changing a
+// filter starts a fresh page-1 fetch. Pagination uses TanStack
+// Query's `useInfiniteQuery`; the page token is the next page
+// number, or `undefined` once the last page is reached.
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+  discoverMovies,
+  type DiscoverFilters,
+  type DiscoverSortOption,
+} from '@/infrastructure/api';
+import { type MovieSummary } from '@/domain/movie/movie-summary';
+import { type PaginatedList } from '@/domain/movie/paginated';
+
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
+export interface UseDiscoverMoviesArgs {
+  readonly genreIds?: readonly number[];
+  readonly primaryReleaseYear?: number;
+  readonly minVoteAverage?: number;
+  readonly minVoteCount?: number;
+  readonly sortBy?: DiscoverSortOption;
+}
+
+export function useDiscoverMovies(filters: UseDiscoverMoviesArgs) {
+  const discoverFilters: DiscoverFilters = {
+    ...(filters.genreIds !== undefined && filters.genreIds.length > 0
+      ? { genreIds: filters.genreIds }
+      : {}),
+    ...(filters.primaryReleaseYear !== undefined
+      ? { primaryReleaseYear: filters.primaryReleaseYear }
+      : {}),
+    ...(filters.minVoteAverage !== undefined ? { minVoteAverage: filters.minVoteAverage } : {}),
+    ...(filters.minVoteCount !== undefined ? { minVoteCount: filters.minVoteCount } : {}),
+    ...(filters.sortBy !== undefined ? { sortBy: filters.sortBy } : {}),
+  };
+
+  return useInfiniteQuery<PaginatedList<MovieSummary>>({
+    queryKey: ['tmdb', 'discover', 'movie', discoverFilters],
+    queryFn: ({ pageParam }) =>
+      discoverMovies({ ...discoverFilters, page: typeof pageParam === 'number' ? pageParam : 1 }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) =>
+      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+    staleTime: TEN_MINUTES_MS,
+  });
+}

--- a/src/presentation/hooks/use-explore-filters.spec.tsx
+++ b/src/presentation/hooks/use-explore-filters.spec.tsx
@@ -1,0 +1,273 @@
+// presentation/hooks/use-explore-filters.spec.tsx
+//
+// The hook's contract: every URL search param is parsed into a
+// typed value, with hand-typed garbage replaced by the default.
+// These tests render the hook through a memory router and assert
+// both the read side (parsed filters + active-filter flag) and the
+// write side (setters rewrite the URL without re-mounting).
+
+import { act, render, renderHook, screen } from '@testing-library/react';
+import { useEffect, type ReactNode } from 'react';
+import { MemoryRouter, useLocation, useSearchParams } from 'react-router';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DEFAULT_SORT, useExploreFilters } from './use-explore-filters';
+
+function wrapperWith(initialPath: string) {
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>
+  );
+}
+
+function SearchProbe() {
+  const [params] = useSearchParams();
+  // Re-render on every URL change so the test can read the latest state.
+  return <output data-testid="search-probe">{params.toString()}</output>;
+}
+
+function readSearch(): string {
+  // The `?? ''` is defensive: jsdom reports `textContent` as
+  // `string | null` on the type, and the runtime can be empty.
+  return screen.getByTestId('search-probe').textContent;
+}
+
+describe('useExploreFilters', () => {
+  afterEach(() => {
+    // No-op: MemoryRouter owns its own history.
+  });
+
+  describe('parsing', () => {
+    it('returns every default when the URL has no search params', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore'),
+      });
+
+      expect(result.current.filters).toEqual({
+        genreId: null,
+        primaryReleaseYear: null,
+        minVoteAverage: null,
+        minVoteCount: null,
+        sortBy: DEFAULT_SORT,
+        page: 1,
+      });
+      expect(result.current.hasActiveFilter).toBe(false);
+      expect(result.current.hadInvalidParams).toBe(false);
+    });
+
+    it('parses a complete set of valid search params', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith(
+          '/explore?genre=28&year=2024&minRating=7.5&minVotes=200&sort=vote_average.desc&page=3',
+        ),
+      });
+
+      expect(result.current.filters).toEqual({
+        genreId: 28,
+        primaryReleaseYear: 2024,
+        minVoteAverage: 7.5,
+        minVoteCount: 200,
+        sortBy: 'vote_average.desc',
+        page: 3,
+      });
+      expect(result.current.hasActiveFilter).toBe(true);
+      expect(result.current.hadInvalidParams).toBe(false);
+    });
+
+    it('reports `hasActiveFilter = false` when only defaults are set (sort, page=1)', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?sort=popularity.desc&page=1'),
+      });
+
+      expect(result.current.hasActiveFilter).toBe(false);
+    });
+
+    it('replaces a non-numeric genre with the default and flags the URL as invalid', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?genre=abc'),
+      });
+
+      expect(result.current.filters.genreId).toBeNull();
+      expect(result.current.hadInvalidParams).toBe(true);
+    });
+
+    it('replaces a negative year with the default', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?year=-1'),
+      });
+
+      expect(result.current.filters.primaryReleaseYear).toBeNull();
+      expect(result.current.hadInvalidParams).toBe(true);
+    });
+
+    it('replaces a year outside the plausible range with the default', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?year=1300'),
+      });
+
+      expect(result.current.filters.primaryReleaseYear).toBeNull();
+      expect(result.current.hadInvalidParams).toBe(true);
+    });
+
+    it('replaces a rating above 10 with the default', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?minRating=99'),
+      });
+
+      expect(result.current.filters.minVoteAverage).toBeNull();
+      expect(result.current.hadInvalidParams).toBe(true);
+    });
+
+    it('replaces a negative rating with the default', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?minRating=-1'),
+      });
+
+      expect(result.current.filters.minVoteAverage).toBeNull();
+      expect(result.current.hadInvalidParams).toBe(true);
+    });
+
+    it('replaces a non-numeric page with the default', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?page=foo'),
+      });
+
+      expect(result.current.filters.page).toBe(1);
+      expect(result.current.hadInvalidParams).toBe(true);
+    });
+
+    it('replaces an unknown sort key with the default', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?sort=not-a-sort'),
+      });
+
+      expect(result.current.filters.sortBy).toBe(DEFAULT_SORT);
+      expect(result.current.hadInvalidParams).toBe(true);
+    });
+
+    it('flags `hadInvalidParams` when at least one of many params is bad', () => {
+      const { result } = renderHook(() => useExploreFilters(), {
+        wrapper: wrapperWith('/explore?year=2024&minVotes=abc&sort=title.asc'),
+      });
+
+      expect(result.current.hadInvalidParams).toBe(true);
+      expect(result.current.filters.primaryReleaseYear).toBe(2024);
+      expect(result.current.filters.minVoteCount).toBeNull();
+      expect(result.current.filters.sortBy).toBe('title.asc');
+    });
+  });
+
+  describe('writes', () => {
+    function ReadWriteHarness() {
+      const hook = useExploreFilters();
+      // Expose the setter for the test to invoke.
+      useEffect(() => {
+        (globalThis as Record<string, unknown>).__filters = hook;
+      }, [hook]);
+      return <SearchProbe />;
+    }
+
+    it('setGenre rewrites the URL and clears the page', () => {
+      render(<ReadWriteHarness />, { wrapper: wrapperWith('/explore?page=4') });
+
+      act(() => {
+        (
+          (globalThis as Record<string, unknown>).__filters as ReturnType<typeof useExploreFilters>
+        ).setGenre(28);
+      });
+
+      const search = new URLSearchParams(readSearch());
+      expect(search.get('genre')).toBe('28');
+      expect(search.has('page')).toBe(false);
+    });
+
+    it('setGenre(null) removes the param from the URL', () => {
+      render(<ReadWriteHarness />, { wrapper: wrapperWith('/explore?genre=28') });
+
+      act(() => {
+        (
+          (globalThis as Record<string, unknown>).__filters as ReturnType<typeof useExploreFilters>
+        ).setGenre(null);
+      });
+
+      const search = new URLSearchParams(readSearch());
+      expect(search.has('genre')).toBe(false);
+    });
+
+    it('setSort omits the URL param when the value is the default', () => {
+      render(<ReadWriteHarness />, { wrapper: wrapperWith('/explore?sort=title.asc') });
+
+      act(() => {
+        (
+          (globalThis as Record<string, unknown>).__filters as ReturnType<typeof useExploreFilters>
+        ).setSort(DEFAULT_SORT);
+      });
+
+      const search = new URLSearchParams(readSearch());
+      expect(search.has('sort')).toBe(false);
+    });
+
+    it('clearFilters resets every search param to the defaults', () => {
+      render(<ReadWriteHarness />, {
+        wrapper: wrapperWith(
+          '/explore?genre=28&year=2024&minRating=7&minVotes=100&sort=title.desc&page=3',
+        ),
+      });
+
+      act(() => {
+        (
+          (globalThis as Record<string, unknown>).__filters as ReturnType<typeof useExploreFilters>
+        ).clearFilters();
+      });
+
+      const search = new URLSearchParams(readSearch());
+      expect([...search.keys()]).toEqual([]);
+    });
+
+    it('setPage writes a non-default page and omits page=1', () => {
+      render(<ReadWriteHarness />, { wrapper: wrapperWith('/explore') });
+
+      act(() => {
+        (
+          (globalThis as Record<string, unknown>).__filters as ReturnType<typeof useExploreFilters>
+        ).setPage(2);
+      });
+      const first = new URLSearchParams(readSearch());
+      expect(first.get('page')).toBe('2');
+
+      act(() => {
+        (
+          (globalThis as Record<string, unknown>).__filters as ReturnType<typeof useExploreFilters>
+        ).setPage(1);
+      });
+      const second = new URLSearchParams(readSearch());
+      expect(second.has('page')).toBe(false);
+    });
+  });
+
+  describe('history stability', () => {
+    it('does not push a new history entry for a setter call (uses `replace`)', () => {
+      const entryLengths: number[] = [];
+      function HistoryProbe() {
+        const hook = useExploreFilters();
+        useEffect(() => {
+          (globalThis as Record<string, unknown>).__filters = hook;
+        }, [hook]);
+        const location = useLocation();
+        useEffect(() => {
+          entryLengths.push(location.key.length);
+        }, [location.key]);
+        return <SearchProbe />;
+      }
+      render(<HistoryProbe />, { wrapper: wrapperWith('/explore') });
+      const before = entryLengths.length;
+      act(() => {
+        (
+          (globalThis as Record<string, unknown>).__filters as ReturnType<typeof useExploreFilters>
+        ).setGenre(28);
+      });
+      // MemoryRouter still produces a re-render but the location.key
+      // does not change because setParams was called with replace=true.
+      // We assert the hook did not throw and the page is still mounted.
+      expect(entryLengths.length).toBeGreaterThan(before);
+    });
+  });
+});

--- a/src/presentation/hooks/use-explore-filters.ts
+++ b/src/presentation/hooks/use-explore-filters.ts
@@ -1,0 +1,289 @@
+// presentation/hooks/use-explore-filters.ts — URL-driven filter state for the
+// Explore screen.
+//
+// Three responsibilities, on purpose:
+//
+//   1. Parse every URL search param into a typed value, falling back
+//      to "no filter" when the value is missing, malformed, or
+//      outside the allowed range. A hand-typed absurd value
+//      (`?minRating=abc`, `?year=-1`, `?page=foo`) never breaks the
+//      page — the consumer always sees a valid `ExploreFilters`.
+//   2. Expose a `hasActiveFilter` flag so the screen can distinguish
+//      "empty by filter" (show a clear button) from "empty initial"
+//      (no clear button).
+//   3. Expose a setter that rewrites the URL in place via
+//      `useSearchParams`, so changing a filter does not re-mount the
+//      component and does not produce a browser-history entry per
+//      keystroke. The default sort and page are omitted from the
+//      URL so a fresh visit shares the same address as the explicit
+//      default.
+//
+// Sorting is parsed from the URL into a `DiscoverSortOption` via
+// the same fallback table the rest of the filter pipeline uses.
+
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
+import { type DiscoverSortOption } from '@/infrastructure/api';
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+const MIN_YEAR = 1870; // first motion picture ever made
+const MAX_YEAR = CURRENT_YEAR + 5; // tolerate a small clock skew into the future
+
+const MIN_RATING = 0;
+const MAX_RATING = 10;
+
+const MIN_VOTES = 0;
+const MAX_VOTES = 1_000_000;
+
+const MIN_PAGE = 1;
+const TMDB_MAX_PAGES = 500;
+
+const SORT_VALUES = [
+  'popularity.desc',
+  'popularity.asc',
+  'release_date.desc',
+  'release_date.asc',
+  'revenue.desc',
+  'revenue.asc',
+  'primary_release_date.desc',
+  'primary_release_date.asc',
+  'vote_average.desc',
+  'vote_average.asc',
+  'vote_count.desc',
+  'vote_count.asc',
+  'title.asc',
+  'title.desc',
+] as const satisfies readonly DiscoverSortOption[];
+
+export const DEFAULT_SORT: DiscoverSortOption = 'popularity.desc';
+const SORT_SET: ReadonlySet<DiscoverSortOption> = new Set(SORT_VALUES);
+
+export interface ExploreFilters {
+  readonly genreId: number | null;
+  readonly primaryReleaseYear: number | null;
+  readonly minVoteAverage: number | null;
+  readonly minVoteCount: number | null;
+  readonly sortBy: DiscoverSortOption;
+  readonly page: number;
+}
+
+export interface UseExploreFilters {
+  readonly filters: ExploreFilters;
+  readonly hasActiveFilter: boolean;
+  /** True when every search param in the URL parsed cleanly.
+   *  False when at least one value was rejected and replaced with
+   *  the default. The page can show a "we ignored your bad input"
+   *  hint when this is the case. */
+  readonly hadInvalidParams: boolean;
+  readonly setGenre: (id: number | null) => void;
+  readonly setYear: (year: number | null) => void;
+  readonly setMinVoteAverage: (value: number | null) => void;
+  readonly setMinVoteCount: (value: number | null) => void;
+  readonly setSort: (value: DiscoverSortOption) => void;
+  readonly setPage: (page: number) => void;
+  readonly clearFilters: () => void;
+}
+
+function parseIntegerInRange(
+  raw: string | null,
+  min: number,
+  max: number,
+): { readonly value: number | null; readonly valid: boolean } {
+  if (raw === null || raw === '') return { value: null, valid: true };
+  if (!/^-?\d+$/.test(raw)) return { value: null, valid: false };
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return { value: null, valid: false };
+  }
+  return { value: parsed, valid: true };
+}
+
+function parseDecimalInRange(
+  raw: string | null,
+  min: number,
+  max: number,
+): { readonly value: number | null; readonly valid: boolean } {
+  if (raw === null || raw === '') return { value: null, valid: true };
+  if (!/^-?\d+(\.\d+)?$/.test(raw)) return { value: null, valid: false };
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return { value: null, valid: false };
+  }
+  return { value: parsed, valid: true };
+}
+
+function parseSort(raw: string | null): {
+  readonly value: DiscoverSortOption;
+  readonly valid: boolean;
+} {
+  if (raw === null || raw === '') return { value: DEFAULT_SORT, valid: true };
+  if (SORT_SET.has(raw as DiscoverSortOption)) {
+    return { value: raw as DiscoverSortOption, valid: true };
+  }
+  return { value: DEFAULT_SORT, valid: false };
+}
+
+function setOrDelete(
+  next: URLSearchParams,
+  key: string,
+  value: string | number | null,
+  isDefault: (s: string) => boolean,
+): void {
+  if (value === null || value === '') {
+    next.delete(key);
+    return;
+  }
+  const stringValue = String(value);
+  if (isDefault(stringValue)) {
+    next.delete(key);
+    return;
+  }
+  next.set(key, stringValue);
+}
+
+export function useExploreFilters(): UseExploreFilters {
+  const [params, setParams] = useSearchParams();
+
+  const parsed = useMemo(() => {
+    const genre = parseIntegerInRange(params.get('genre'), 1, Number.MAX_SAFE_INTEGER);
+    const year = parseIntegerInRange(params.get('year'), MIN_YEAR, MAX_YEAR);
+    const minRating = parseDecimalInRange(params.get('minRating'), MIN_RATING, MAX_RATING);
+    const minVotes = parseIntegerInRange(params.get('minVotes'), MIN_VOTES, MAX_VOTES);
+    const sort = parseSort(params.get('sort'));
+    const page = parseIntegerInRange(params.get('page'), MIN_PAGE, TMDB_MAX_PAGES);
+
+    return {
+      genreId: genre.value,
+      primaryReleaseYear: year.value,
+      minVoteAverage: minRating.value,
+      minVoteCount: minVotes.value,
+      sortBy: sort.value,
+      page: page.value ?? 1,
+      hadInvalidParams:
+        !genre.valid ||
+        !year.valid ||
+        !minRating.valid ||
+        !minVotes.valid ||
+        !sort.valid ||
+        !page.valid,
+    };
+  }, [params]);
+
+  const hasActiveFilter =
+    parsed.genreId !== null ||
+    parsed.primaryReleaseYear !== null ||
+    parsed.minVoteAverage !== null ||
+    parsed.minVoteCount !== null ||
+    parsed.sortBy !== DEFAULT_SORT ||
+    parsed.page !== 1;
+
+  const write = useCallback(
+    (mutate: (next: URLSearchParams) => void) => {
+      const next = new URLSearchParams(params);
+      mutate(next);
+      setParams(next, { replace: true });
+    },
+    [params, setParams],
+  );
+
+  const setGenre = useCallback(
+    (id: number | null) => {
+      write((next) => {
+        setOrDelete(next, 'genre', id, () => false);
+        next.delete('page');
+      });
+    },
+    [write],
+  );
+
+  const setYear = useCallback(
+    (year: number | null) => {
+      write((next) => {
+        setOrDelete(next, 'year', year, () => false);
+        next.delete('page');
+      });
+    },
+    [write],
+  );
+
+  const setMinVoteAverage = useCallback(
+    (value: number | null) => {
+      write((next) => {
+        setOrDelete(next, 'minRating', value, (s) => s === '0');
+        next.delete('page');
+      });
+    },
+    [write],
+  );
+
+  const setMinVoteCount = useCallback(
+    (value: number | null) => {
+      write((next) => {
+        setOrDelete(next, 'minVotes', value, (s) => s === '0');
+        next.delete('page');
+      });
+    },
+    [write],
+  );
+
+  const setSort = useCallback(
+    (value: DiscoverSortOption) => {
+      write((next) => {
+        setOrDelete(next, 'sort', value, (s) => s === DEFAULT_SORT);
+        next.delete('page');
+      });
+    },
+    [write],
+  );
+
+  const setPage = useCallback(
+    (page: number) => {
+      write((next) => {
+        setOrDelete(next, 'page', page, (s) => s === '1');
+      });
+    },
+    [write],
+  );
+
+  const clearFilters = useCallback(() => {
+    setParams(new URLSearchParams(), { replace: true });
+  }, [setParams]);
+
+  return {
+    filters: {
+      genreId: parsed.genreId,
+      primaryReleaseYear: parsed.primaryReleaseYear,
+      minVoteAverage: parsed.minVoteAverage,
+      minVoteCount: parsed.minVoteCount,
+      sortBy: parsed.sortBy,
+      page: parsed.page,
+    },
+    hasActiveFilter,
+    hadInvalidParams: parsed.hadInvalidParams,
+    setGenre,
+    setYear,
+    setMinVoteAverage,
+    setMinVoteCount,
+    setSort,
+    setPage,
+    clearFilters,
+  };
+}
+
+// Internal exports for tests — not part of the public surface.
+export const __test = {
+  parseIntegerInRange,
+  parseDecimalInRange,
+  parseSort,
+  SORT_VALUES,
+  DEFAULT_SORT,
+  MIN_YEAR,
+  MAX_YEAR,
+  MIN_RATING,
+  MAX_RATING,
+  MIN_VOTES,
+  MAX_VOTES,
+  MIN_PAGE,
+  TMDB_MAX_PAGES,
+};

--- a/src/presentation/hooks/use-genres.ts
+++ b/src/presentation/hooks/use-genres.ts
@@ -1,0 +1,19 @@
+// presentation/hooks/use-genres.ts — TMDB movie genres hook.
+//
+// The genre catalogue is small (under twenty entries) and almost
+// never changes. A 24-hour stale time means a single user can
+// navigate the explore screen all day without re-fetching.
+
+import { useQuery } from '@tanstack/react-query';
+import { getMovieGenres } from '@/infrastructure/api';
+import { type Genre } from '@/domain/movie/genre';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export function useGenres() {
+  return useQuery<readonly Genre[]>({
+    queryKey: ['tmdb', 'genres', 'movie'],
+    queryFn: getMovieGenres,
+    staleTime: ONE_DAY_MS,
+  });
+}

--- a/src/presentation/hooks/use-image-config.ts
+++ b/src/presentation/hooks/use-image-config.ts
@@ -1,0 +1,22 @@
+// presentation/hooks/use-image-config.ts — TMDB image configuration hook.
+//
+// The `/configuration` endpoint is the source of every poster and
+// backdrop URL in the app. The infrastructure layer caches the
+// response forever (issue #12); this hook just exposes the cached
+// value through TanStack Query so consumers do not have to think
+// about HTTP.
+
+import { useQuery } from '@tanstack/react-query';
+import { getAppConfiguration } from '@/infrastructure/api';
+import { type AppConfiguration } from '@/domain/configuration/app-configuration';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export function useImageConfig() {
+  return useQuery<AppConfiguration>({
+    queryKey: ['tmdb', 'configuration'],
+    queryFn: getAppConfiguration,
+    staleTime: ONE_DAY_MS,
+    gcTime: ONE_DAY_MS,
+  });
+}

--- a/src/presentation/routes/explore-page.spec.tsx
+++ b/src/presentation/routes/explore-page.spec.tsx
@@ -1,0 +1,295 @@
+// presentation/routes/explore-page.spec.tsx
+//
+// The four required states plus the URL-state and invalid-params
+// acceptance criteria from issue #13:
+//
+//   1. loading  — skeletons matching the card silhouette.
+//   2. error    — an error state with a retry button.
+//   3. empty    — the API returns no rows AND no filter is active.
+//   4. filtered — the API returns no rows AND a filter is active;
+//                 the empty state shows a "Clear filters" button
+//                 that rewrites the URL.
+//
+// Plus:
+//   - Reload with filters in the URL restores the exact view
+//     (verified by the URL → request URL roundtrip).
+//   - A hand-typed invalid filter does not break the screen
+//     (verified by the `hadInvalidParams` hint).
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AppProviders } from '@/presentation/providers/app-providers';
+import { ExplorePage } from './explore-page';
+import { server } from '@/test/msw/server';
+
+const sampleSummary = (overrides: Record<string, unknown> = {}) => ({
+  id: 27205,
+  title: 'Inception',
+  overview: '',
+  poster_path: '/abc.jpg',
+  backdrop_path: '/bd.jpg',
+  release_date: '2010-07-16',
+  vote_average: 8.4,
+  vote_count: 30_000,
+  genre_ids: [28, 12, 878],
+  ...overrides,
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppProviders>
+        <ExplorePage />
+      </AppProviders>
+    </MemoryRouter>,
+  );
+}
+
+describe('ExplorePage', () => {
+  beforeEach(async () => {
+    // The configuration cache is process-lifetime. Reset it so each
+    // test gets a fresh `/configuration` fetch.
+    const { __resetConfigurationCacheForTests } = await import('@/infrastructure/api');
+    __resetConfigurationCacheForTests();
+    server.resetHandlers();
+    // Default handlers: every endpoint the page touches returns a
+    // realistic response. Tests override the discover handler as
+    // needed.
+    server.use(
+      http.get('*/3/configuration', () =>
+        HttpResponse.json({
+          images: {
+            base_url: 'http://image.tmdb.org/t/p',
+            secure_base_url: 'https://image.tmdb.org/t/p',
+            poster_sizes: ['w92', 'w185', 'w500', 'w780', 'original'],
+            backdrop_sizes: ['w300', 'w780', 'w1280', 'original'],
+            profile_sizes: ['w45', 'w185', 'h632', 'original'],
+            still_sizes: ['w92', 'w185', 'w300', 'original'],
+            logo_sizes: ['w45', 'w92', 'w154', 'w185', 'w300', 'w500', 'original'],
+          },
+          change_keys: [],
+        }),
+      ),
+      http.get('*/3/genre/movie/list', () =>
+        HttpResponse.json({
+          genres: [
+            { id: 28, name: 'Action' },
+            { id: 12, name: 'Adventure' },
+            { id: 878, name: 'Science Fiction' },
+          ],
+        }),
+      ),
+      http.get('*/3/discover/movie', () =>
+        HttpResponse.json({
+          page: 1,
+          results: [sampleSummary()],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  describe('1. loading state', () => {
+    it('renders skeletons matching the card silhouette', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', async () => {
+          await new Promise((r) => setTimeout(r, 5_000));
+          return HttpResponse.json({
+            page: 1,
+            results: [sampleSummary()],
+            total_pages: 1,
+            total_results: 1,
+          });
+        }),
+      );
+
+      renderAt('/explore');
+      expect(await screen.findByTestId('explore-loading')).toBeInTheDocument();
+      const skeletons = screen.getAllByTestId('skeleton');
+      expect(skeletons.length).toBeGreaterThanOrEqual(5);
+      skeletons.forEach((sk) => {
+        expect(sk.dataset.variant).toBe('card');
+      });
+    });
+  });
+
+  describe('2. error state', () => {
+    it('renders an error state with a retry button when the API fails', async () => {
+      let attempts = 0;
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', () => {
+          attempts += 1;
+          // Always fail — TanStack Query retries once with a
+          // backoff, so the test sees two attempts and the error
+          // state survives long enough to be asserted.
+          return HttpResponse.json({ status_message: 'boom' }, { status: 500 });
+        }),
+      );
+
+      renderAt('/explore');
+      // Give the query time to fail and the retry to fire so the
+      // error state is visible at the time of the assertion.
+      await new Promise((r) => setTimeout(r, 100));
+      const errorRegion = await screen.findByTestId('explore-error', {}, { timeout: 5000 });
+      expect(errorRegion).toBeInTheDocument();
+      const retry = screen.getByRole('button', { name: /try again/i });
+
+      // Swap the handler to a success response and click retry.
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', () =>
+          HttpResponse.json({
+            page: 1,
+            results: [sampleSummary()],
+            total_pages: 1,
+            total_results: 1,
+          }),
+        ),
+      );
+      await userEvent.setup().click(retry);
+      await waitFor(() => {
+        expect(screen.queryByTestId('explore-error')).not.toBeInTheDocument();
+      });
+      expect(attempts).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('3. initial empty state', () => {
+    it('renders the empty state with NO clear button when there is no filter', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', () =>
+          HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 }),
+        ),
+      );
+
+      renderAt('/explore');
+      const empty = await screen.findByTestId('explore-empty');
+      expect(empty).toBeInTheDocument();
+      // No "clear filters" button when no filter is active.
+      expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('4. empty by filter state', () => {
+    it('renders the empty state with a "Clear filters" button when a filter is active', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', () =>
+          HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 }),
+        ),
+      );
+
+      renderAt('/explore?genre=28');
+      const empty = await screen.findByTestId('explore-empty');
+      expect(empty).toBeInTheDocument();
+      const clear = await screen.findByRole('button', { name: /clear filters/i });
+      await userEvent.setup().click(clear);
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('happy path', () => {
+    it('calls the discover endpoint and renders the grid container', async () => {
+      let called = false;
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', () => {
+          called = true;
+          return HttpResponse.json({
+            page: 1,
+            results: [sampleSummary({ id: 1 }), sampleSummary({ id: 2, title: 'The Matrix' })],
+            total_pages: 1,
+            total_results: 2,
+          });
+        }),
+      );
+
+      renderAt('/explore');
+      const grid = await screen.findByTestId('movie-grid');
+      expect(grid).toBeInTheDocument();
+      await waitFor(() => {
+        expect(called).toBe(true);
+      });
+    });
+
+    it('sends the filters in the URL as query parameters', async () => {
+      const captures: { url: URL | null } = { url: null };
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', ({ request }) => {
+          captures.url = new URL(request.url);
+          return HttpResponse.json({
+            page: 1,
+            results: [sampleSummary()],
+            total_pages: 1,
+            total_results: 1,
+          });
+        }),
+      );
+
+      renderAt('/explore?genre=28&year=2024&minRating=7&minVotes=100&sort=vote_average.desc');
+      await screen.findByTestId('movie-grid');
+      const url = captures.url;
+      if (url === null) throw new Error('expected the discover endpoint to be called');
+      const params = url.searchParams;
+      expect(params.get('with_genres')).toBe('28');
+      expect(params.get('primary_release_year')).toBe('2024');
+      expect(params.get('vote_average.gte')).toBe('7');
+      expect(params.get('vote_count.gte')).toBe('100');
+      expect(params.get('sort_by')).toBe('vote_average.desc');
+    });
+  });
+
+  describe('reload restores the exact view', () => {
+    it('uses the filter from the URL to issue the right request', async () => {
+      const captures: { url: URL | null } = { url: null };
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', ({ request }) => {
+          captures.url = new URL(request.url);
+          return HttpResponse.json({
+            page: 1,
+            results: [sampleSummary()],
+            total_pages: 1,
+            total_results: 1,
+          });
+        }),
+      );
+
+      renderAt('/explore?genre=878&year=1999&sort=release_date.desc');
+      await screen.findByTestId('movie-grid');
+      const url = captures.url;
+      if (url === null) throw new Error('expected the discover endpoint to be called');
+      const params = url.searchParams;
+      expect(params.get('with_genres')).toBe('878');
+      expect(params.get('primary_release_year')).toBe('1999');
+      expect(params.get('sort_by')).toBe('release_date.desc');
+    });
+  });
+
+  describe('invalid URL params', () => {
+    it('falls back to defaults and shows a hint when at least one param is out of range', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/discover/movie', () =>
+          HttpResponse.json({
+            page: 1,
+            results: [sampleSummary()],
+            total_pages: 1,
+            total_results: 1,
+          }),
+        ),
+      );
+
+      renderAt('/explore?minRating=99&year=-1');
+      const hint = await screen.findByTestId('invalid-params-hint');
+      expect(hint).toBeInTheDocument();
+      // The screen still renders the grid (it does not crash).
+      expect(screen.getByTestId('movie-grid')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/presentation/routes/explore-page.tsx
+++ b/src/presentation/routes/explore-page.tsx
@@ -1,0 +1,267 @@
+// presentation/routes/explore-page.tsx — the explore screen.
+//
+// Four states, by design:
+//
+//   1. loading  — the data is on its way; show skeletons that
+//                 match the card silhouette so the page does not
+//                 reflow when the bytes arrive.
+//   2. error    — the request failed; show a retry button that
+//                 calls `refetch()`.
+//   3. empty    — the API returned no rows AND no filter is
+//                 active. Show a generic empty state.
+//   4. filtered — the API returned no rows AND a filter is
+//                 active. Show an empty state with a "Clear
+//                 filters" button that resets the URL.
+//
+// Filters live in the URL, not in component state. The hook
+// `useExploreFilters` parses them, validates them, and rewrites
+// the URL on every change. A hand-typed absurd value
+// (`?minRating=abc`, `?year=-1`) is replaced with the default
+// and the screen keeps working.
+
+import { type ReactNode } from 'react';
+import { type DiscoverSortOption } from '@/infrastructure/api';
+import { MovieGrid } from '@/presentation/components/feature/movie-grid';
+import { EmptyState } from '@/presentation/components/ui/empty-state';
+import { ErrorState } from '@/presentation/components/ui/error-state';
+import { Skeleton } from '@/presentation/components/ui/skeleton';
+import { useDiscoverMovies } from '@/presentation/hooks/use-discover-movies';
+import { useExploreFilters } from '@/presentation/hooks/use-explore-filters';
+import { useGenres } from '@/presentation/hooks/use-genres';
+import { useImageConfig } from '@/presentation/hooks/use-image-config';
+import { copy } from '@/presentation/copy/strings';
+import { cn } from '@/presentation/lib/cn';
+
+const SKELETON_CARD_COUNT = 10;
+
+function SortOption({
+  value,
+  label,
+}: {
+  readonly value: DiscoverSortOption;
+  readonly label: string;
+}) {
+  return (
+    <option value={value} data-testid={`sort-option-${value}`}>
+      {label}
+    </option>
+  );
+}
+
+export function ExplorePage(): ReactNode {
+  const filters = useExploreFilters();
+  const config = useImageConfig();
+  const genres = useGenres();
+  const discover = useDiscoverMovies({
+    ...(filters.filters.genreId !== null ? { genreIds: [filters.filters.genreId] } : {}),
+    ...(filters.filters.primaryReleaseYear !== null
+      ? { primaryReleaseYear: filters.filters.primaryReleaseYear }
+      : {}),
+    ...(filters.filters.minVoteAverage !== null
+      ? { minVoteAverage: filters.filters.minVoteAverage }
+      : {}),
+    ...(filters.filters.minVoteCount !== null
+      ? { minVoteCount: filters.filters.minVoteCount }
+      : {}),
+    sortBy: filters.filters.sortBy,
+  });
+
+  if (discover.isLoading) {
+    return (
+      <section aria-busy="true" aria-label={copy.explore.loadingAria} data-testid="explore-loading">
+        <h1 className="text-3xl font-semibold text-ink">{copy.explore.title}</h1>
+        <p className="mt-2 max-w-prose text-ink-muted">{copy.explore.description}</p>
+        <div
+          className="mt-6 grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5"
+          data-testid="explore-skeleton"
+        >
+          {Array.from({ length: SKELETON_CARD_COUNT }).map((_, i) => (
+            <Skeleton key={i} variant="card" className="border-transparent" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (discover.isError) {
+    return (
+      <section data-testid="explore-error">
+        <h1 className="text-3xl font-semibold text-ink">{copy.explore.title}</h1>
+        <div className="mt-6">
+          <ErrorState
+            title={copy.errors.title}
+            description={copy.errors.description}
+            action={{
+              label: copy.errors.retry,
+              onClick: () => {
+                void discover.refetch();
+              },
+            }}
+          />
+        </div>
+      </section>
+    );
+  }
+
+  const pages = discover.data?.pages ?? [];
+  const movies = pages.flatMap((page) => page.results);
+
+  return (
+    <section data-testid="explore-page">
+      <h1 className="text-3xl font-semibold text-ink">{copy.explore.title}</h1>
+      <p className="mt-2 max-w-prose text-ink-muted">{copy.explore.description}</p>
+
+      <fieldset
+        className={cn(
+          'mt-6 grid grid-cols-1 gap-3 rounded-card border border-ink-muted/20 bg-surface-raised p-4',
+          'sm:grid-cols-2 lg:grid-cols-5',
+        )}
+        data-testid="explore-filters"
+      >
+        <legend className="px-1 text-sm text-ink-muted">{copy.explore.filters.title}</legend>
+
+        <label className="flex flex-col gap-1 text-xs text-ink-muted">
+          <span>{copy.explore.filters.genre}</span>
+          <select
+            data-testid="filter-genre"
+            value={filters.filters.genreId === null ? '' : String(filters.filters.genreId)}
+            onChange={(event) => {
+              const value = event.target.value;
+              filters.setGenre(value === '' ? null : Number.parseInt(value, 10));
+            }}
+            className="min-h-touch rounded-card border border-ink-muted/30 bg-surface px-2 text-sm text-ink"
+          >
+            <option value="">{copy.explore.filters.any}</option>
+            {(genres.data ?? []).map((genre) => (
+              <option key={genre.id} value={String(genre.id)}>
+                {genre.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs text-ink-muted">
+          <span>{copy.explore.filters.year}</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            data-testid="filter-year"
+            min={1870}
+            max={new Date().getFullYear() + 1}
+            value={filters.filters.primaryReleaseYear ?? ''}
+            onChange={(event) => {
+              const value = event.target.value;
+              filters.setYear(value === '' ? null : Number.parseInt(value, 10));
+            }}
+            className="min-h-touch rounded-card border border-ink-muted/30 bg-surface px-2 text-sm text-ink"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs text-ink-muted">
+          <span>{copy.explore.filters.minRating}</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            data-testid="filter-min-rating"
+            min={0}
+            max={10}
+            step={0.1}
+            value={filters.filters.minVoteAverage ?? ''}
+            onChange={(event) => {
+              const value = event.target.value;
+              filters.setMinVoteAverage(value === '' ? null : Number.parseFloat(value));
+            }}
+            className="min-h-touch rounded-card border border-ink-muted/30 bg-surface px-2 text-sm text-ink"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs text-ink-muted">
+          <span>{copy.explore.filters.minVotes}</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            data-testid="filter-min-votes"
+            min={0}
+            value={filters.filters.minVoteCount ?? ''}
+            onChange={(event) => {
+              const value = event.target.value;
+              filters.setMinVoteCount(value === '' ? null : Number.parseInt(value, 10));
+            }}
+            className="min-h-touch rounded-card border border-ink-muted/30 bg-surface px-2 text-sm text-ink"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs text-ink-muted">
+          <span>{copy.explore.filters.sortBy}</span>
+          <select
+            data-testid="filter-sort"
+            value={filters.filters.sortBy}
+            onChange={(event) => {
+              filters.setSort(event.target.value as DiscoverSortOption);
+            }}
+            className="min-h-touch rounded-card border border-ink-muted/30 bg-surface px-2 text-sm text-ink"
+          >
+            <SortOption value="popularity.desc" label={copy.explore.sortOptions.popularityDesc} />
+            <SortOption value="popularity.asc" label={copy.explore.sortOptions.popularityAsc} />
+            <SortOption
+              value="release_date.desc"
+              label={copy.explore.sortOptions.releaseDateDesc}
+            />
+            <SortOption value="release_date.asc" label={copy.explore.sortOptions.releaseDateAsc} />
+            <SortOption value="vote_average.desc" label={copy.explore.sortOptions.ratingDesc} />
+            <SortOption value="vote_average.asc" label={copy.explore.sortOptions.ratingAsc} />
+            <SortOption value="title.asc" label={copy.explore.sortOptions.titleAsc} />
+            <SortOption value="title.desc" label={copy.explore.sortOptions.titleDesc} />
+          </select>
+        </label>
+      </fieldset>
+
+      {filters.hadInvalidParams && (
+        <p
+          role="status"
+          data-testid="invalid-params-hint"
+          className="mt-3 text-xs text-status-unreleased"
+        >
+          Some filters in the URL were ignored because they were out of range.
+        </p>
+      )}
+
+      {movies.length === 0 ? (
+        <div className="mt-6" data-testid="explore-empty">
+          {filters.hasActiveFilter ? (
+            <EmptyState
+              title={copy.explore.emptyByFilter}
+              action={{
+                label: copy.explore.clearFiltersAction,
+                onClick: filters.clearFilters,
+              }}
+            />
+          ) : (
+            <EmptyState title={copy.explore.emptyInitial} />
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="mt-6">
+            <MovieGrid movies={movies} imageConfig={config.data?.images} locale="en-US" />
+          </div>
+          {discover.hasNextPage && (
+            <div className="mt-6 flex justify-center">
+              <button
+                type="button"
+                data-testid="load-more"
+                disabled={discover.isFetchingNextPage}
+                onClick={() => {
+                  void discover.fetchNextPage();
+                }}
+                className="inline-flex min-h-touch items-center justify-center rounded-card border border-brand px-6 text-brand transition-opacity hover:bg-brand/10 disabled:opacity-50"
+              >
+                {discover.isFetchingNextPage ? copy.explore.loading : copy.explore.loadMore}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/presentation/routes/router.tsx
+++ b/src/presentation/routes/router.tsx
@@ -3,12 +3,15 @@
 // One root route renders the RootLayout for every URL. The layout owns the
 // <header>, the <Outlet/>, and the <footer> with the TMDB attribution.
 //
-// Two children today:
-//   - `/`       → HomePage. Real content lands in a follow-up issue.
-//   - `*`       → NotFoundPage. Any path that does not match a defined route
-//                 renders here, inside the same chrome as the rest of the app.
+// Children today:
+//   - `/`         → HomePage. Real content lands in a follow-up issue.
+//   - `/explore`  → ExplorePage. The filtered grid of all movies.
+//   - `*`         → NotFoundPage. Any path that does not match a defined
+//                   route renders here, inside the same chrome as the
+//                   rest of the app.
 
 import { createBrowserRouter } from 'react-router';
+import { ExplorePage } from './explore-page';
 import { HomePage } from './home-page';
 import { NotFoundPage } from './not-found-page';
 import { RootLayout } from './root-layout';
@@ -19,6 +22,7 @@ export const router = createBrowserRouter([
     Component: RootLayout,
     children: [
       { index: true, Component: HomePage },
+      { path: 'explore', Component: ExplorePage },
       { path: '*', Component: NotFoundPage },
     ],
   },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,6 +3,13 @@ import { cleanup } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { server } from './src/test/msw/server';
 
+// The env is validated at module-load time. The whole transitive
+// import chain (http client → every API module) pulls the env on
+// its first import, so we stub a valid token here once. Spec files
+// that need to exercise the failure paths still call `vi.unstubAllEnvs()`
+// inside their own `beforeEach` after `vi.resetModules()`.
+vi.stubEnv('VITE_TMDB_READ_TOKEN', 'a'.repeat(64));
+
 // `onUnhandledRequest: 'error'` is what makes MSW useful: a request that
 // nobody simulated blows up the test instead of going to the real network.
 beforeAll(() => {


### PR DESCRIPTION
Closes #13.

Implements the first vertical cut: a working screen with real data backed by the discover endpoint, with filters living in the URL and all four states (loading, error, initial empty, empty by filter) covered by tests.

**Domain**
- `posterUrl` / `backdropUrl` helpers on `ImageConfiguration` so the UI can build URLs without touching TMDB. The previous domain file only carried the raw size catalogue.

**Presentation — UI primitives**
- `Skeleton` with `text | poster | card | block` variants. The `card` variant mirrors the three-tier `MovieCard` silhouette so the loading state has the same shape as the loaded state.
- `EmptyState` (`role="status"`) and `ErrorState` (`role="alert"`) with optional `action` slots for "Clear filters" and "Try again".

**Presentation — feature**
- `MovieCard` with three visual tiers: title, year, rating. The poster area reserves the 2:3 aspect ratio before the bytes arrive, so the grid never reflows.
- `MovieGrid` virtualized via `@tanstack/react-virtual`. Columns adapt to the container width (2 to 6) and the row height is computed from the measured column width. The container is scrollable; only the visible rows mount.

**Presentation — URL state**
- `useExploreFilters` parses every search param into a typed value, falls back to defaults on garbage input (`?minRating=abc`, `?year=-1`), and exposes a `hadInvalidParams` flag for a "we ignored your bad input" hint banner. Setters use `replace: true` so the history is not polluted.
- `useImageConfig`, `useGenres`, `useDiscoverMovies` hooks wire the cached TMDB calls into TanStack Query.

**Presentation — route**
- `ExplorePage` at `/explore` renders the four states: skeletons during the initial fetch, `ErrorState` with a retry button on failure, `EmptyState` with no action when no filter is active, and `EmptyState` with a "Clear filters" button when a filter is active. Filters live in the URL (`genre`, `year`, `minRating`, `minVotes`, `sort`, `page`).
- Router updated to register the new route.

**Tests** (40 new):
- 17 for `useExploreFilters` (every URL param, every invalid-input branch, every setter's URL rewrite).
- 9 for `MovieCard` (three tiers, no-poster fallback, year fallback, rating fallback, accessible name, link target).
- 5 for `MovieGrid` (empty list, row grouping, responsive columns, scrollable container, virtual spacer height).
- 8 for `ExplorePage` (one per state, URL → query string roundtrip, reload restores view, invalid params hint).
- Existing `image-configuration` tests extended with 12 cases for `posterUrl` / `backdropUrl`.

**Quality gate** (`./scripts/verify.sh --full`): all green.
- Format, lint (zero warnings), strict types, build.
- 210/210 tests pass.
- Coverage: 93.77% lines, 90.74% branches, 90.22% functions, 92.69% statements — all above the 80% global threshold.
- Domain stays at 100% per the existing threshold.