### PR TITLE
feat(infra): typed schema errors + 500-page clamp at the API boundary

### DIFF
--- a/src/infrastructure/api/_shared.spec.ts
+++ b/src/infrastructure/api/_shared.spec.ts
@@ -1,0 +1,115 @@
+// infrastructure/api/_shared.spec.ts
+//
+// Verifies the two boundary guarantees shared by every endpoint
+// module (issue #24 acceptance criteria):
+//
+//   1. A drifted response shape surfaces as a `TmdbSchemaError`
+//      with a readable message and per-path issues — never as a
+//      raw `ZodError` dump.
+//   2. The requested page is clamped into `[1, 500]` so the API
+//      layer itself respects TMDB's hard cap, regardless of any
+//      presentation-layer guard.
+
+import { z } from 'zod';
+import { describe, expect, it } from 'vitest';
+import { TmdbSchemaError, clampPage, parseWith } from './_shared';
+
+const schema = z.object({ id: z.number(), title: z.string() });
+
+describe('infrastructure/api/_shared', () => {
+  describe('parseWith', () => {
+    it('returns the parsed value when the data matches the schema', () => {
+      const parsed = parseWith(schema, { id: 1, title: 'Inception' }, '/3/test');
+      expect(parsed).toEqual({ id: 1, title: 'Inception' });
+    });
+
+    it('throws a TmdbSchemaError (not a ZodError) when a field is broken', () => {
+      expect.assertions(4);
+      try {
+        parseWith(schema, { id: 'not-a-number', title: 'Inception' }, '/3/test');
+        throw new Error('expected parseWith to throw');
+      } catch (cause: unknown) {
+        expect(cause).toBeInstanceOf(TmdbSchemaError);
+        expect(cause).not.toBeInstanceOf(z.ZodError);
+        const error = cause as TmdbSchemaError;
+        expect(error.endpoint).toBe('/3/test');
+        expect(error.name).toBe('TmdbSchemaError');
+      }
+    });
+
+    it('carries a human-readable message naming the endpoint and first failing path', () => {
+      try {
+        parseWith(schema, { id: 'oops', title: 42 }, '/3/discover/movie');
+        throw new Error('expected parseWith to throw');
+      } catch (cause: unknown) {
+        const error = cause as TmdbSchemaError;
+        expect(error.message).toContain('/3/discover/movie');
+        expect(error.message).toContain('id');
+        // One line per failing path, in schema order.
+        expect(error.issues.length).toBe(2);
+        expect(error.issues[0]).toMatch(/^id:/);
+        expect(error.issues[1]).toMatch(/^title:/);
+      }
+    });
+
+    it('renders <root> for issues that are not attached to a path', () => {
+      try {
+        parseWith(z.string(), 42, '/3/test');
+        throw new Error('expected parseWith to throw');
+      } catch (cause: unknown) {
+        const error = cause as TmdbSchemaError;
+        expect(error.issues[0]).toMatch(/^<root>:/);
+      }
+    });
+
+    it('preserves the original ZodError as the error cause', () => {
+      try {
+        parseWith(schema, {}, '/3/test');
+        throw new Error('expected parseWith to throw');
+      } catch (cause: unknown) {
+        expect((cause as TmdbSchemaError).cause).toBeInstanceOf(z.ZodError);
+      }
+    });
+
+    it('rethrows non-Zod failures untouched', () => {
+      const exploding = {
+        parse: () => {
+          throw new Error('boom');
+        },
+      } as unknown as z.ZodType<{ id: number }>;
+      expect(() => parseWith(exploding, {}, '/3/test')).toThrow('boom');
+    });
+  });
+
+  describe('clampPage', () => {
+    it('passes undefined through so the param stays unset', () => {
+      expect(clampPage(undefined)).toBeUndefined();
+    });
+
+    it('maps non-finite values to undefined so nothing invalid is sent', () => {
+      expect(clampPage(Number.NaN)).toBeUndefined();
+      expect(clampPage(Number.POSITIVE_INFINITY)).toBeUndefined();
+    });
+
+    it('clamps below the floor to page 1', () => {
+      expect(clampPage(0)).toBe(1);
+      expect(clampPage(-5)).toBe(1);
+    });
+
+    it('keeps in-range pages untouched', () => {
+      expect(clampPage(1)).toBe(1);
+      expect(clampPage(250)).toBe(250);
+      expect(clampPage(500)).toBe(500);
+    });
+
+    it('clamps above the cap to page 500', () => {
+      expect(clampPage(501)).toBe(500);
+      expect(clampPage(10_000)).toBe(500);
+    });
+
+    it('truncates fractional pages toward zero before clamping', () => {
+      expect(clampPage(2.9)).toBe(2);
+      expect(clampPage(600.5)).toBe(500);
+    });
+  });
+});

--- a/src/infrastructure/api/_shared.ts
+++ b/src/infrastructure/api/_shared.ts
@@ -22,6 +22,85 @@ import { type RatingReliability } from '@/domain/rating/rating-reliability';
 import { type Trailer } from '@/domain/movie/trailer';
 
 // =============================================================================
+// Boundary errors + shared parsing
+// =============================================================================
+//
+// A broken field in a TMDB response must surface as a typed,
+// readable boundary error — never as a raw `ZodError` dump. This
+// mirrors the HTTP edge: network failures become `TmdbHttpError`
+// (see `infrastructure/http/errors.ts`), shape failures become
+// `TmdbSchemaError`.
+
+/**
+ * Thrown when a TMDB response does not match its documented shape.
+ * Carries the endpoint that lied plus a short list of human-readable
+ * issues so logs point at the actual drift instead of a parser dump.
+ */
+export class TmdbSchemaError extends Error {
+  override name = 'TmdbSchemaError' as const;
+  /** The endpoint whose response failed validation, e.g. `/3/discover/movie`. */
+  readonly endpoint: string;
+  /** Human-readable rendering of every failing path. */
+  readonly issues: readonly string[];
+
+  constructor(endpoint: string, cause: z.ZodError) {
+    const issues = cause.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+      return `${path}: ${issue.message}`;
+    });
+    super(
+      `TMDB response from ${endpoint} failed validation (${String(issues.length)} issue(s)): ${issues[0] ?? 'unknown'}`,
+    );
+    this.endpoint = endpoint;
+    this.issues = issues;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Parse untrusted data against a Zod schema at the API boundary.
+ * On failure, throws `TmdbSchemaError` (never a raw `ZodError`) so
+ * callers pattern-match one boundary error family, like they do
+ * for `TmdbHttpError`.
+ */
+export function parseWith<T>(schema: z.ZodType<T>, data: unknown, endpoint: string): T {
+  try {
+    return schema.parse(data);
+  } catch (cause: unknown) {
+    if (cause instanceof z.ZodError) {
+      throw new TmdbSchemaError(endpoint, cause);
+    }
+    throw cause;
+  }
+}
+
+// =============================================================================
+// Pagination guard
+// =============================================================================
+
+/**
+ * TMDB documents a hard cap of 500 pages on every paginated
+ * endpoint; asking beyond it returns TMDB body code 22. The API
+ * layer clamps instead of trusting the caller so the guarantee
+ * holds even if a presentation-layer guard is added later —
+ * the same belt-and-braces reasoning as the URL parser.
+ */
+export const TMDB_MAX_PAGE = 500;
+
+/**
+ * Clamp a requested page into `[1, TMDB_MAX_PAGE]`.
+ *
+ *   - `undefined` / non-finite → `undefined` (param not sent).
+ *   - `< 1`                    → `1`.
+ *   - `> 500`                  → `500`.
+ *   - fractional values        → truncated toward zero first.
+ */
+export function clampPage(page: number | undefined): number | undefined {
+  if (page === undefined || !Number.isFinite(page)) return undefined;
+  return Math.min(Math.max(Math.trunc(page), 1), TMDB_MAX_PAGE);
+}
+
+// =============================================================================
 // Raw TMDB Zod schemas
 // =============================================================================
 //
@@ -151,7 +230,7 @@ function toTrailers(rawArr: readonly z.infer<typeof tmdbTrailerSchema>[]): reado
  * `released` / `unreleased` boundary to a known instant.
  */
 export function toMovieSummary(raw: unknown, now: Date = new Date()): MovieSummary {
-  const parsed = tmdbMovieSummarySchema.parse(raw);
+  const parsed = parseWith(tmdbMovieSummarySchema, raw, 'shared/movie-summary');
   return {
     id: parsed.id,
     title: parsed.title,
@@ -170,7 +249,7 @@ export function toMovieSummary(raw: unknown, now: Date = new Date()): MovieSumma
  * domain `MovieDetail`. `now` is injectable for testing.
  */
 export function toMovieDetail(raw: unknown, now: Date = new Date()): MovieDetail {
-  const parsed = tmdbMovieDetailFullSchema.parse(raw);
+  const parsed = parseWith(tmdbMovieDetailFullSchema, raw, 'shared/movie-detail');
 
   const cast: NoData<readonly CastMember[]> =
     parsed.credits === null || parsed.credits === undefined

--- a/src/infrastructure/api/configuration.ts
+++ b/src/infrastructure/api/configuration.ts
@@ -24,6 +24,7 @@
 
 import { z } from 'zod';
 import { tmdbHttpClient } from '@/infrastructure/http/client';
+import { parseWith } from './_shared';
 import type { AppConfiguration } from '@/domain/configuration/app-configuration';
 
 // Zod schema for the TMDB /configuration response. Only the fields
@@ -69,7 +70,7 @@ let cached: Promise<AppConfiguration> | undefined;
 function fetchAndParse(): Promise<AppConfiguration> {
   return tmdbHttpClient
     .get<unknown>('/3/configuration')
-    .then((data) => configurationResponseSchema.parse(data))
+    .then((data) => parseWith(configurationResponseSchema, data, '/3/configuration'))
     .then(toAppConfiguration);
 }
 
@@ -78,9 +79,9 @@ function fetchAndParse(): Promise<AppConfiguration> {
  * successful read; subsequent calls return the same promise so the
  * network is hit once per app lifetime.
  *
- * Throws a ZodError if TMDB returns a response that no longer
- * matches the expected shape. Errors raised by the HTTP client
- * (rate limits, network failures) propagate unchanged as
+ * Throws a `TmdbSchemaError` if TMDB returns a response that no
+ * longer matches the expected shape. Errors raised by the HTTP
+ * client (rate limits, network failures) propagate unchanged as
  * `TmdbHttpError`.
  */
 export function getAppConfiguration(): Promise<AppConfiguration> {

--- a/src/infrastructure/api/discover.spec.ts
+++ b/src/infrastructure/api/discover.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/msw/server';
+import { z } from 'zod';
 
 const BASE = 'https://api.tmdb.test';
 const TOKEN = 'a'.repeat(64);
@@ -151,6 +152,65 @@ describe('infrastructure/api/discover', () => {
 
     const { discoverMovies } = await import('./discover');
     await expect(discoverMovies()).rejects.toThrow();
+  });
+
+  it('surfaces a drifted response shape as a typed TmdbSchemaError, not a ZodError', async () => {
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, () =>
+        HttpResponse.json({
+          page: 'not-a-number',
+          results: [],
+          total_pages: 0,
+          total_results: 0,
+        }),
+      ),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    const { TmdbSchemaError } = await import('./_shared');
+    try {
+      await discoverMovies();
+      throw new Error('expected discoverMovies to reject');
+    } catch (cause: unknown) {
+      expect(cause).toBeInstanceOf(TmdbSchemaError);
+      expect(cause).not.toBeInstanceOf(z.ZodError);
+      // Structural assertion: keeps the check independent of how
+      // the class resolves through the dynamic import above.
+      const error = cause as { endpoint: string; message: string; issues: readonly string[] };
+      expect(error.endpoint).toBe('/3/discover/movie');
+      expect(error.message).toContain('/3/discover/movie');
+      expect(error.issues.some((issue) => issue.startsWith('page:'))).toBe(true);
+    }
+  });
+
+  it('clamps a page beyond the TMDB cap to 500 before sending the request', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 500, results: [], total_pages: 500, total_results: 0 });
+      }),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    const result = await discoverMovies({ page: 501 });
+    expect(assertedUrl(requestedUrl).searchParams.get('page')).toBe('500');
+    // The response is echoed as-is; the clamp is about what we send.
+    expect(result.page).toBe(500);
+  });
+
+  it('clamps an out-of-range page below the floor to page 1', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/discover/movie`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 });
+      }),
+    );
+
+    const { discoverMovies } = await import('./discover');
+    await discoverMovies({ page: 0 });
+    expect(assertedUrl(requestedUrl).searchParams.get('page')).toBe('1');
   });
 
   it('propagates HTTP errors as TmdbHttpError (e.g. invalid page)', async () => {

--- a/src/infrastructure/api/discover.ts
+++ b/src/infrastructure/api/discover.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { tmdbHttpClient } from '@/infrastructure/http/client';
-import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { clampPage, parseWith, tmdbMovieSummarySchema, toMovieSummary } from './_shared';
 import { type MovieSummary } from '@/domain/movie/movie-summary';
 import { type PaginatedList } from '@/domain/movie/paginated';
 
@@ -55,6 +55,7 @@ function toQueryParams(filters: DiscoverFilters): Record<string, string | number
   // Spread construction keeps every key a literal that the linter
   // accepts as dot-notation friendly while keeping the param object
   // sparse (unset filters are not sent).
+  const page = clampPage(filters.page);
   return {
     ...(filters.genreIds && filters.genreIds.length > 0
       ? { with_genres: filters.genreIds.join(',') }
@@ -65,7 +66,7 @@ function toQueryParams(filters: DiscoverFilters): Record<string, string | number
     ...(filters.minVoteAverage !== undefined ? { 'vote_average.gte': filters.minVoteAverage } : {}),
     ...(filters.minVoteCount !== undefined ? { 'vote_count.gte': filters.minVoteCount } : {}),
     ...(filters.sortBy !== undefined ? { sort_by: filters.sortBy } : {}),
-    ...(filters.page !== undefined ? { page: filters.page } : {}),
+    ...(page !== undefined ? { page } : {}),
     ...(filters.includeAdult !== undefined ? { include_adult: filters.includeAdult } : {}),
   };
 }
@@ -85,8 +86,10 @@ function toPaginatedMovies(
 /**
  * Discover movies matching the given filters. Returns a paginated
  * domain list — `results` are `MovieSummary` objects, not raw TMDB
- * JSON. Each `result` is validated with the shared schema, so a
- * broken field in the response surfaces a localized `ZodError`.
+ * JSON. A response whose shape drifted (a renamed field, a string
+ * where a number belongs) surfaces as a `TmdbSchemaError`, never
+ * as a raw `ZodError`. The requested page is clamped to TMDB's
+ * 500-page cap before the request leaves this module.
  */
 export function discoverMovies(
   filters: DiscoverFilters = {},
@@ -94,6 +97,6 @@ export function discoverMovies(
   const params = toQueryParams(filters);
   return tmdbHttpClient
     .get<unknown>('/3/discover/movie', { params })
-    .then((data) => discoverResponseSchema.parse(data))
+    .then((data) => parseWith(discoverResponseSchema, data, '/3/discover/movie'))
     .then((parsed) => toPaginatedMovies(parsed));
 }

--- a/src/infrastructure/api/genres.ts
+++ b/src/infrastructure/api/genres.ts
@@ -12,6 +12,7 @@
 
 import { z } from 'zod';
 import { tmdbHttpClient } from '@/infrastructure/http/client';
+import { parseWith } from './_shared';
 import type { Genre } from '@/domain/movie/genre';
 
 const genreSchema = z.object({
@@ -37,6 +38,6 @@ function toGenres(raw: GenresResponse): readonly Genre[] {
 export function getMovieGenres(): Promise<readonly Genre[]> {
   return tmdbHttpClient
     .get<unknown>('/3/genre/movie/list')
-    .then((data) => genresResponseSchema.parse(data))
+    .then((data) => parseWith(genresResponseSchema, data, '/3/genre/movie/list'))
     .then(toGenres);
 }

--- a/src/infrastructure/api/index.ts
+++ b/src/infrastructure/api/index.ts
@@ -3,10 +3,11 @@
  *
  * Re-exports the seven endpoint modules the rest of the app
  * consumes (`configuration`, `genres`, `discover`, `search`,
- * `movie`, `recommendations`, `trending`) and nothing else. The
- * raw-schema / mapper helpers (`./_shared`) are internal and not
- * re-exported — domain types live in `src/domain/**` and should
- * be imported from there.
+ * `movie`, `recommendations`, `trending`) plus `TmdbSchemaError`,
+ * the typed error a caller sees when a response shape drifted.
+ * The raw-schema / mapper helpers (`./_shared`) remain internal —
+ * domain types live in `src/domain/**` and should be imported
+ * from there.
  *
  * @see docs/architecture.md — "Where does this file go?".
  */
@@ -18,3 +19,4 @@ export { searchMovies, type SearchParams } from './search';
 export { getMovieDetail, type MovieDetailParams } from './movie';
 export { getMovieRecommendations, type MovieRecommendationsParams } from './recommendations';
 export { getTrendingMovies, type TrendingParams, type TrendingTimeWindow } from './trending';
+export { TmdbSchemaError } from './_shared';

--- a/src/infrastructure/api/recommendations.ts
+++ b/src/infrastructure/api/recommendations.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { tmdbHttpClient } from '@/infrastructure/http/client';
-import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { clampPage, parseWith, tmdbMovieSummarySchema, toMovieSummary } from './_shared';
 import { type MovieSummary } from '@/domain/movie/movie-summary';
 import { type PaginatedList } from '@/domain/movie/paginated';
 
@@ -39,12 +39,19 @@ function toPaginatedMovies(
 export function getMovieRecommendations(
   params: MovieRecommendationsParams,
 ): Promise<PaginatedList<MovieSummary>> {
+  const page = clampPage(params.page);
   const query: Record<string, number> = {
-    ...(params.page !== undefined ? { page: params.page } : {}),
+    ...(page !== undefined ? { page } : {}),
   };
   const config = Object.keys(query).length > 0 ? { params: query } : undefined;
   return tmdbHttpClient
     .get<unknown>(`/3/movie/${String(params.id)}/recommendations`, config)
-    .then((data) => recommendationsResponseSchema.parse(data))
+    .then((data) =>
+      parseWith(
+        recommendationsResponseSchema,
+        data,
+        `/3/movie/${String(params.id)}/recommendations`,
+      ),
+    )
     .then((parsed) => toPaginatedMovies(parsed));
 }

--- a/src/infrastructure/api/search.spec.ts
+++ b/src/infrastructure/api/search.spec.ts
@@ -121,6 +121,22 @@ describe('infrastructure/api/search', () => {
       detail: { kind: 'invalidPage' },
     });
   });
+
+  it('clamps the requested page into the [1, 500] TMDB range', async () => {
+    const captured: URL[] = [];
+    server.use(
+      http.get(`${BASE}/3/search/movie`, ({ request }) => {
+        captured.push(new URL(request.url));
+        return HttpResponse.json({ page: 1, results: [], total_pages: 0, total_results: 0 });
+      }),
+    );
+
+    const { searchMovies } = await import('./search');
+    await searchMovies({ query: 'q', page: 501 });
+    await searchMovies({ query: 'q', page: -3 });
+    expect(captured[0]?.searchParams.get('page')).toBe('500');
+    expect(captured[1]?.searchParams.get('page')).toBe('1');
+  });
 });
 
 function assertedUrl(value: URL | null): URL {

--- a/src/infrastructure/api/search.ts
+++ b/src/infrastructure/api/search.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { tmdbHttpClient } from '@/infrastructure/http/client';
-import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { clampPage, parseWith, tmdbMovieSummarySchema, toMovieSummary } from './_shared';
 import { type MovieSummary } from '@/domain/movie/movie-summary';
 import { type PaginatedList } from '@/domain/movie/paginated';
 
@@ -25,9 +25,10 @@ const searchResponseSchema = z.object({
 type SearchResponse = z.infer<typeof searchResponseSchema>;
 
 function toQueryParams(params: SearchParams): Record<string, string | number | boolean> {
+  const page = clampPage(params.page);
   return {
     query: params.query,
-    ...(params.page !== undefined ? { page: params.page } : {}),
+    ...(page !== undefined ? { page } : {}),
     ...(params.includeAdult !== undefined ? { include_adult: params.includeAdult } : {}),
     ...(params.primaryReleaseYear !== undefined
       ? { primary_release_year: params.primaryReleaseYear }
@@ -52,12 +53,14 @@ function toPaginatedMovies(
  * list; each result is a validated `MovieSummary` (no raw TMDB
  * JSON). Empty results come back as an empty `results` array,
  * not as an error — searching for nothing matched is a normal
- * "empty by filter" state, not a failure.
+ * "empty by filter" state, not a failure. A drifted response
+ * shape surfaces as `TmdbSchemaError`; the requested page is
+ * clamped to TMDB's 500-page cap.
  */
 export function searchMovies(params: SearchParams): Promise<PaginatedList<MovieSummary>> {
   const query = toQueryParams(params);
   return tmdbHttpClient
     .get<unknown>('/3/search/movie', { params: query })
-    .then((data) => searchResponseSchema.parse(data))
+    .then((data) => parseWith(searchResponseSchema, data, '/3/search/movie'))
     .then((parsed) => toPaginatedMovies(parsed));
 }

--- a/src/infrastructure/api/trending.spec.ts
+++ b/src/infrastructure/api/trending.spec.ts
@@ -122,6 +122,20 @@ describe('infrastructure/api/trending', () => {
       detail: { kind: 'invalidApiKey' },
     });
   });
+
+  it('clamps a page beyond the TMDB cap to 500 before sending the request', async () => {
+    let requestedUrl: URL | null = null;
+    server.use(
+      http.get(`${BASE}/3/trending/movie/day`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({ page: 500, results: [], total_pages: 500, total_results: 0 });
+      }),
+    );
+
+    const { getTrendingMovies } = await import('./trending');
+    await getTrendingMovies({ timeWindow: 'day', page: 999 });
+    expect(assertedUrl(requestedUrl).searchParams.get('page')).toBe('500');
+  });
 });
 
 function assertedUrl(value: URL | null): URL {

--- a/src/infrastructure/api/trending.ts
+++ b/src/infrastructure/api/trending.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { tmdbHttpClient } from '@/infrastructure/http/client';
-import { tmdbMovieSummarySchema, toMovieSummary } from './_shared';
+import { clampPage, parseWith, tmdbMovieSummarySchema, toMovieSummary } from './_shared';
 import { type MovieSummary } from '@/domain/movie/movie-summary';
 import { type PaginatedList } from '@/domain/movie/paginated';
 
@@ -23,8 +23,9 @@ const trendingResponseSchema = z.object({
 type TrendingResponse = z.infer<typeof trendingResponseSchema>;
 
 function toQueryParams(params: TrendingParams): Record<string, string | number | boolean> {
+  const page = clampPage(params.page);
   return {
-    ...(params.page !== undefined ? { page: params.page } : {}),
+    ...(page !== undefined ? { page } : {}),
     ...(params.includeAdult !== undefined ? { include_adult: params.includeAdult } : {}),
   };
 }
@@ -44,13 +45,17 @@ function toPaginatedMovies(
 /**
  * Fetch the trending movies for the requested time window.
  * Returns a paginated domain list; each result is a validated
- * `MovieSummary` (no raw TMDB JSON leaks).
+ * `MovieSummary` (no raw TMDB JSON leaks). A drifted response
+ * shape surfaces as `TmdbSchemaError`; the requested page is
+ * clamped to TMDB's 500-page cap.
  */
 export function getTrendingMovies(params: TrendingParams): Promise<PaginatedList<MovieSummary>> {
   return tmdbHttpClient
     .get<unknown>(`/3/trending/movie/${params.timeWindow}`, {
       params: toQueryParams(params),
     })
-    .then((data) => trendingResponseSchema.parse(data))
+    .then((data) =>
+      parseWith(trendingResponseSchema, data, `/3/trending/movie/${params.timeWindow}`),
+    )
     .then((parsed) => toPaginatedMovies(parsed));
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? Link to the issue it closes. -->

Closes the two acceptance criteria of issue #24 that the earlier endpoint work (PRs #72/#77) left open. The five core endpoint modules, their Zod schemas, and the MSW handlers already exist on `main`; this PR hardens the boundary itself:

### 1. Drifted responses surface as a typed error, not a Zod dump

A response whose shape drifted (renamed field, string where a number belongs) used to throw a raw `ZodError` — a giant English parse dump with no context about which endpoint lied. Every module now parses through a shared `parseWith(schema, data, endpoint)` helper that translates the failure into **`TmdbSchemaError`**:

- names the lying endpoint (`/3/discover/movie`),
- carries one human-readable line per failing path (`issues: ['page: Expected number, received string', …]`),
- preserves the original `ZodError` as `cause`,
- mirrors the existing `TmdbHttpError` pattern from the network edge, and is exported from the api index so callers pattern-match one boundary error family.

Applied across all seven modules (`configuration`, `genres`, `discover`, `search`, `movie`, `recommendations`, `trending`) plus the two shared mappers.

### 2. Pagination respects the 500-page cap at this layer

The cap only lived in presentation hooks (`use-explore-filters`, `use-discover-movies`); the API layer forwarded any page and relied on TMDB rejecting it with body code 22. All four paginated modules (`discover`, `search`, `trending`, `recommendations`) now clamp the requested page into `[1, 500]` via a shared `clampPage` helper — `undefined`/non-finite stays unset, `< 1` → `1`, `> 500` → `500`, fractions truncated. Same belt-and-braces reasoning as the URL parser.

Closes #24

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, just code improvement)
- [ ] Chore / Maintenance (dependency upgrade, tooling, docs)
- [ ] Performance improvement
- [x] Test only _(17 new tests)_

## What Changed

- `src/infrastructure/api/_shared.ts` — new `TmdbSchemaError`, `parseWith`, `TMDB_MAX_PAGE`, `clampPage`; mappers switched to `parseWith`.
- `src/infrastructure/api/{discover,search,trending,recommendations}.ts` — `parseWith` + page clamp.
- `src/infrastructure/api/{configuration,genres}.ts` — `parseWith`.
- `src/infrastructure/api/index.ts` — exports `TmdbSchemaError`.
- `src/infrastructure/api/_shared.spec.ts` — _new_, 12 tests for the helpers.
- `discover/search/trending.spec.ts` — 5 integration tests: typed-error path via a broken MSW field, cap clamping observed on captured request URLs.

## Affected Layers

- [ ] `domain/` — pure TypeScript, no framework imports
- [ ] `application/` — use cases and ports
- [x] `infrastructure/` — HTTP, storage, API
- [ ] `presentation/` — React, routes, hooks

## Screenshots / Recordings

### Before / After

N/A — infrastructure behaviour, verified by tests.

## How to Test

1. Pull the branch: `git fetch && git checkout feature/infra-endpoint-hardening`
2. Run `pnpm test` — 449 total, all green; watch the new `_shared.spec.ts` plus the clamp/schema-error cases in discover/search/trending specs.
3. Quick manual probe of the typed error: point an MSW handler at `/3/discover/movie` returning `{ page: "oops", results: [] , ...}` and observe `TmdbSchemaError: TMDB response from /3/discover/movie failed validation (1 issue(s)): page: …`.

## Tests

- [x] I added unit tests for the new logic
- [x] I updated existing tests that no longer apply
- [x] I verified the manual test plan above
- [x] Coverage has not decreased (domain still 100 % lines)

## Quality Gate

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm check-types` passes
- [x] `pnpm test` passes (coverage thresholds met)
- [x] `pnpm build` succeeds
- [x] `./scripts/check-versions.sh` reports no deprecated deps

Verified locally with `bash scripts/verify.sh --full` (86 s, GREEN).

## Checklist

- [x] My code follows the project's architecture rules (domain is pure, dependencies point inward)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious
- [x] I have updated the documentation (README, copy, etc.) if needed
- [x] I have read the Cineteca Project Guide and the Baseline Guide

## Deployment Notes

- _None_ — no env vars, no migrations, no config toggles. Error-type swap is additive: anything that caught generic `Error` keeps working.

## Reviewer Focus

- @reviewer please look at
  - `src/infrastructure/api/_shared.ts` — `TmdbSchemaError` message construction (first issue inlined, full list in `.issues`) and `clampPage`'s truncation-before-clamp order.
  - `src/infrastructure/api/discover.spec.ts` — the structural assertion on the caught error (independent of how the class resolves through the spec's dynamic import).