### PR TITLE
fix(test): restore jsdom localStorage under Node 25+ empty stub

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,6 +13,28 @@ vi.stubEnv('VITE_TMDB_READ_TOKEN', 'a'.repeat(64));
 // `onUnhandledRequest: 'error'` is what makes MSW useful: a request that
 // nobody simulated blows up the test instead of going to the real network.
 beforeAll(() => {
+  // Node 25+ ships a built-in `localStorage` global as part of the
+  // Web Storage API. With v25.0.0 the global is unflagged (v22 only
+  // exposes it behind `--experimental-webstorage`; v26 will throw a
+  // DOMException instead of returning an empty object). When
+  // `--localstorage-file` is not provided to a valid path on v25,
+  // the global is an empty stub object with no methods
+  // (`setItem`/`getItem`/`clear`/etc. are all `undefined`). Vitest's
+  // `populateGlobal` walks the jsdom window and only assigns keys that
+  // are NOT already on `global` (or are in its allow-list); since
+  // `localStorage` is neither, vitest skips it and Node's stub wins.
+  // Every spec that touches `window.localStorage` then explodes with
+  // "localStorage.clear is not a function". Replacing the stub with
+  // jsdom's real Storage at file setup restores the expected behaviour
+  // and is a no-op on Node versions where `localStorage` is undefined.
+  const jsdomInstance = (globalThis as { jsdom?: { window: { localStorage: Storage } } }).jsdom;
+  if (jsdomInstance) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: jsdomInstance.window.localStorage,
+      writable: true,
+      configurable: true,
+    });
+  }
   server.listen({ onUnhandledRequest: 'error' });
 });
 afterEach(async () => {


### PR DESCRIPTION
## Description

Fixes the failing-test cascade introduced by Node 25+ shipping a built-in `localStorage` global as a stub object. The change is **22 lines in `vitest.setup.ts`** (replaces the 18-line block added in the now-closed #90 with the same content + a corrected version comment). No source-code or spec changes.

Supersedes #90. That PR was opened with `fix/` as the branch prefix, which is outside the allow-list in `CONTRIBUTING.md` § Branching model. Per Sebastian's review, renamed to `bugfix/` (the correct home — this restores failing behaviour, so `bugfix` not `chore`). PR #90 is being closed in a follow-up comment.

### Background

Node **25.0.0** unflagged `localStorage` as part of the Web Storage API:
- **v22**: the global is hidden behind `--experimental-webstorage` — stock CI Node 22 does **not** define it.
- **v25.0.0**: unflagged. Without `--localstorage-file`, accessing `localStorage` returns an **empty object** (no methods).
- **v26**: accessing it without a file throws a `DOMException` instead.

The mismatch between what contributors run (Node ≥ 25) and what CI pins (Node 22) is **why CI stayed green while local `pnpm test` blew up with 590 failures**.

When the empty stub exists on `global`, vitest 4's `populateGlobal` walks the jsdom window and only assigns keys that are NOT already on `global` (or are in its allow-list). Since `localStorage` is neither, vitest skips it — and Node's stub wins over jsdom's real `Storage`.

The `afterEach` in `vitest.setup.ts:48` calls `window.localStorage.clear()` after every test. When that throws, three cleanup steps silently break:
1. `cleanup()` from `@testing-library/react` does not run → DOM is not reset.
2. `__resetLibraryRepositoryForTests()` / `__resetListsRepositoryForTests()` do not run → the singleton repositories keep state from the previous test.
3. The next test sees dirty DOM, dirty storage, and mutated repositories, and fails for a different reason.

The cascade explains the **590 failures** seen on `pnpm test` on Node 25+: most are not bugs in the specs, they are the afterEach teardown failing on the very first test and contaminating every subsequent one. Isolating a single spec file (`save-to-library-button.spec.tsx`) on Node 22 (where the bug does not exist) shows 6/6 pass; on Node 25+ without this patch, those same 6 specs fail with the cascade pattern.

### Fix

In `vitest.setup.ts`'s `beforeAll`, before MSW listens, replace `globalThis.localStorage` with jsdom's real `Storage` instance via `Object.defineProperty`. Guarded by `if (jsdomInstance)` so non-jsdom environments (e.g. edge-runtime if added later) are untouched.

```ts
const jsdomInstance = (globalThis as { jsdom?: { window: { localStorage: Storage } } }).jsdom;
if (jsdomInstance) {
  Object.defineProperty(globalThis, 'localStorage', {
    value: jsdomInstance.window.localStorage,
    writable: true,
    configurable: true,
  });
}
```

`globalThis.jsdom` is the handle vitest exposes on the worker global **just before** setupFiles run, so the override is in place before any spec executes. On Node versions that don't define `localStorage`, the `defineProperty` re-asserts jsdom's already-installed Storage — a no-op that costs nothing.

### Verification

| Check | Before fix (Node 25+ local) | After fix (Node 25+ local) | CI on Node 22 |
| --- | --- | --- | --- |
| `pnpm test` (full) | 590 failed | **469 passed** in ~13s | 469 passed (no-op) |
| Coverage statements | (gate blocked) | 91.3% (≥80% ✅) | 91.3% ✅ |
| Coverage branches | — | 84.62% (≥80% ✅) | 84.62% ✅ |
| Coverage `src/domain/**` | — | 100% (≥100% ✅) | 100% ✅ |
| `pnpm format:check` | ✅ | ✅ | ✅ |
| `pnpm lint` | ✅ | ✅ | ✅ |
| `pnpm check-types` | ✅ | ✅ | ✅ |
| `pnpm build` | ✅ | ✅ | ✅ |

Sebastian's review on the prior PR included an empirical reproduction (simulating Node 25 with `--require` preload defining `globalThis.localStorage = {}`): on `develop` without this patch, `save-to-library-button.spec.tsx` fails 6/6 with exactly the described cascade; on this branch, 6/6 pass and the full suite is 469/469 with no test-to-test contamination.

### Notes

- The fix is a **runtime workaround**, not a version pin. If/when vitest adds `localStorage` to its allow-list (or jsdom stops honouring Node's stub), the override becomes a no-op and can be deleted.
- One concern per branch: no source-code or spec changes ride along.
- Toolchain drift (CI Node 22 vs contributor Node 25+) is a separate, larger issue. Filing separately so this fix isn't only a workaround in test setup.

Refs #81 — the local-lists PR that exercised `window.localStorage` via the SaveToLibraryButton spec and unmasked the bug.
Refs the `afterEach` teardown in `vitest.setup.ts`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, just code improvement)
- [ ] Chore / Maintenance (dependency upgrade, tooling, docs)
- [ ] Performance improvement
- [ ] Test only

## Branch Naming

- [x] My branch starts with `feature/`, `bugfix/`, `chore/`, `release/`, or `hotfix/`
- [x] My branch name is lowercase, kebab-case, and follows `<prefix>/<scope>-<short-desc>` (no issue number in the name)
- [x] I branched off `develop` (or off `main` for `hotfix/` and `release/`)

> Renamed from `fix/test-restore-jsdom-localstorage` to `bugfix/test-restore-jsdom-localstorage` per review feedback. The Conventional-Commit type (`fix(test):`) is unchanged — that type is allowed for any bug, including infra bugs — but the **branch** prefix follows the documented allow-list.

## What Changed

- `vitest.setup.ts` — added 22 lines in `beforeAll` that override `globalThis.localStorage` with the real `Storage` exposed by jsdom. Guarded by `if (jsdomInstance)` so the override is a no-op on non-jsdom environments. Block comment corrected from `Node v22+` to `Node 25+` and notes the v22/v26 behaviour for debugging context.

## Affected Layers

- [ ] `domain/` — pure TypeScript, no framework imports
- [ ] `application/` — use cases and ports
- [ ] `infrastructure/` — HTTP, storage, API
- [ ] `presentation/` — React, routes, hooks

## How to Test

1. Pull `bugfix/test-restore-jsdom-localstorage`
2. Run `bash scripts/verify.sh --full`
3. Confirm `Tests  469 passed (469)` and no `Test Files  failed`
4. (Node 25+ only — regression check) `pnpm exec vitest run --no-coverage src/presentation/components/feature/save-to-library-button.spec.tsx` — must show 6/6 pass. On Node 22 the bug is not reproducible; that's expected.

## Tests

- [ ] I added unit tests for the new logic (N/A — runtime test-environment fix; behaviour is covered by the 469 specs that now pass)
- [ ] I updated existing tests that no longer apply (none)
- [x] I verified the manual test plan above (469/469 locally on Node 25, 469/469 on CI on Node 22; 6/6 spot-check on the file that originally unmasked the bug)
- [x] Coverage has not decreased (91.3% statements, 84.62% branches, 89.53% functions, 93.06% lines; `src/domain/**` still 100%)

## Quality Gate

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm check-types` passes
- [x] `pnpm test` passes (coverage thresholds met)
- [x] `pnpm build` succeeds
- [x] `./scripts/check-versions.sh` reports no deprecated deps introduced by this PR

## Checklist

- [x] My code follows the project's architecture rules (domain is pure, dependencies point inward)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious (block comment explains the Node-vs-vitest interaction and corrects the version claim)
- [x] I have updated the documentation (README, copy, etc.) if needed (N/A — runtime workaround; comment in source is sufficient)
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

- _None_ — test-environment only; production bundles are unaffected.

## Reviewer Focus

- `@reviewer` please look at `vitest.setup.ts` lines 16–37 — confirm the `Object.defineProperty` semantics are correct (`writable: true` lets future test code mutate `localStorage`; `configurable: true` lets the override be torn down if needed). The cast `globalThis as { jsdom?: ... }` is intentional because `jsdom` is a vitest-only runtime handle and is not in the project's ambient types.
- Confirm the version comment now matches reality (`Node 25+`, not `Node v22+`). v22/v26 behaviour is documented for debugging context.
- Confirm `Closes #81` was replaced with `Refs #81` — #81 is a merged PR, not an open issue.

---

> By submitting this pull request, I confirm that my contribution is made under the project's license and that I have the right to submit it.