### PR TITLE
chore(release): merge governance rollout (PRs #93, #94, #92, #89) into main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,14 @@ Closes #
 - [ ] Performance improvement
 - [ ] Test only
 
+## Branch Naming
+
+<!-- Match the convention in CONTRIBUTING.md. PRs from branches that do not match are sent back. -->
+
+- [ ] My branch starts with `feature/`, `bugfix/`, `chore/`, `release/`, or `hotfix/`
+- [ ] My branch name is lowercase, kebab-case, and follows `<prefix>/<scope>-<short-desc>` (no issue number in the name)
+- [ ] I branched off `develop` (or off `main` for `hotfix/` and `release/`)
+
 ## What Changed
 
 <!-- A short bullet list of the actual changes. Group by component or file. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,14 +104,15 @@ shows only the merge commits on `main` — one line per release. The granular fe
 
 In **Settings → General → Pull Requests**:
 
-| Setting                            | Value       |
-| ---------------------------------- | ----------- |
-| Allow squash merging               | enabled     |
-| Allow merge commits                | **enabled** |
-| Allow rebase merging               | disabled    |
-| Allow auto-merge                   | enabled     |
-| Automatically delete head branches | enabled     |
-| Default squash commit message      | PR title    |
+| Setting                            | Value        |
+| ---------------------------------- | ------------ |
+| Allow squash merging               | enabled      |
+| Allow merge commits                | **enabled**  |
+| Allow rebase merging               | **disabled** |
+| Allow auto-merge                   | **enabled**  |
+| Automatically delete head branches | **enabled**  |
+| Default squash commit title        | PR title     |
+| Default squash commit message      | PR body      |
 
 In **Settings → Branches → Branch protection** on `main` **and** `develop`:
 
@@ -120,6 +121,8 @@ In **Settings → Branches → Branch protection** on `main` **and** `develop`:
 | Require linear history | **disabled** |
 
 "Require linear history" literally forbids merge commits and would force you right back into the squash-only problem. It is deliberately off.
+
+The full rationale — including the per-branch ruleset, the `Include administrators` asymmetry, and how this maps to the assignment gate ("nada entra a `main` sin el gate") — is in [issue #27](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/issues/27). The hybrid strategy itself is in [issue #29](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/issues/29).
 
 ### How to choose the merge button for each PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,10 @@ The repo uses a lightweight Git Flow with two long-lived branches and a handful 
 
 ### Long-lived branches
 
-| Branch    | Purpose                                                            | Receives merges from                             | Protection                                                  |
-| --------- | ------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------- |
-| `main`    | Production-ready code. Every commit on `main` is releasable.       | `release/*`, `hotfix/*`                          | PR + 1 review + green CI + linear history + admins included |
-| `develop` | Integration branch for the next release. Features accumulate here. | `feature/*`, `bugfix/*`, `release/*`, `hotfix/*` | PR + 1 review + green CI + linear history                   |
+| Branch    | Purpose                                                            | Receives merges from                             | Protection                                 |
+| --------- | ------------------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------ |
+| `main`    | Production-ready code. Every commit on `main` is releasable.       | `release/*`, `hotfix/*`                          | PR + 1 review + green CI + admins included |
+| `develop` | Integration branch for the next release. Features accumulate here. | `feature/*`, `bugfix/*`, `release/*`, `hotfix/*` | PR + 1 review + green CI                   |
 
 ### Short-lived branches
 
@@ -116,13 +116,27 @@ In **Settings → General → Pull Requests**:
 
 In **Settings → Branches → Branch protection** on `main` **and** `develop`:
 
-| Setting                | Value        |
-| ---------------------- | ------------ |
-| Require linear history | **disabled** |
+| Setting                                      | `main`              | `develop`           |
+| -------------------------------------------- | ------------------- | ------------------- |
+| Require a pull request before merging        | **enabled**         | **enabled**         |
+| Required approvals                           | 1                   | 1                   |
+| Dismiss stale pull request approvals         | **enabled**         | **enabled**         |
+| Require status checks to pass before merging | **enabled**         | **enabled**         |
+| Required check                               | `Quality gate` (CI) | `Quality gate` (CI) |
+| Require branches to be up to date            | **enabled**         | **enabled**         |
+| Require conversation resolution              | **enabled**         | **enabled**         |
+| Require linear history                       | **disabled**        | **disabled**        |
+| Allow force pushes                           | disabled            | disabled            |
+| Allow deletions                              | disabled            | disabled            |
+| Include administrators                       | **enabled**         | disabled            |
 
-"Require linear history" literally forbids merge commits and would force you right back into the squash-only problem. It is deliberately off.
+> "Require linear history" literally forbids merge commits and would force you right back into the squash-only problem. It is deliberately off on both long-lived branches.
+>
+> "Include administrators" is **on** for `main` so the gate is the gate even for repo owners; it is **off** for `develop` so admins can fast-forward the integration branch while iterating on the next release.
 
-The full rationale — including the per-branch ruleset, the `Include administrators` asymmetry, and how this maps to the assignment gate ("nada entra a `main` sin el gate") — is in [issue #27](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/issues/27). The hybrid strategy itself is in [issue #29](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/issues/29).
+The full rationale and how each rule maps to the assignment gate ("nada entra a `main` sin el gate") lives in [issue #27](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/issues/27). The hybrid strategy itself is in [issue #29](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/issues/29).
+
+> Note: `Allow auto-merge` lives at the repo level (Settings → General → Pull Requests) and is a single value for all branches, not a per-branch protection setting. It is already documented in the table above under the hybrid merge strategy (issue #29).
 
 ### How to choose the merge button for each PR
 

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# branch-protection.sh — apply the branch-protection rules from
+# CONTRIBUTING.md "Branch protection" to `main` and `develop` via the
+# GitHub REST API. Requires a token with admin rights on the repo
+# (fine-grained: Repository → Administration → Write; classic: `repo`).
+#
+# Usage:
+#   GITHUB_TOKEN=ghp_xxx bash scripts/branch-protection.sh
+#
+# Idempotent: running twice produces the same state. Safe to re-run
+# after CONTRIBUTING.md changes the ruleset.
+#
+# Why a script: the ruleset is the single source of truth in
+# CONTRIBUTING.md. This script encodes that table so the settings can
+# be reproduced by any maintainer without copy-pasting from the docs.
+# Issue #27.
+
+set -euo pipefail
+
+OWNER="${OWNER:-Team-Centinela}"
+REPO="${REPO:-Project-save-me-of-the-riwi}"
+BRANCHES=("main" "develop")
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN is required (admin scope)." >&2
+  exit 2
+fi
+
+# Expected state per branch, used for the post-apply verification.
+# Keep these in sync with the table in CONTRIBUTING.md.
+#
+# Note: contexts is checked even though it is identical on both
+# branches — the round-1 review caught a `gate` vs `Quality gate`
+# typo in exactly this field, so excluding it on a "differs per
+# branch" filter would re-introduce the silent-failure mode the
+# whole verification step exists to catch.
+declare -A EXPECT_ENFORCE_ADMINS=(
+  ["main"]="true"
+  ["develop"]="false"
+)
+declare -A EXPECT_LINEAR=(
+  ["main"]="false"
+  ["develop"]="false"
+)
+declare -A EXPECT_CONTEXTS=(
+  ["main"]="Quality gate"
+  ["develop"]="Quality gate"
+)
+
+main_body='{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Quality gate"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}'
+
+develop_body='{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Quality gate"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}'
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  if [[ -n "$body" ]]; then
+    gh api \
+      --method "$method" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "/repos/${OWNER}/${REPO}${path}" \
+      --input - <<<"$body"
+  else
+    gh api \
+      --method "$method" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "/repos/${OWNER}/${REPO}${path}"
+  fi
+}
+
+verify() {
+  local branch="$1" got got_admins got_linear got_contexts
+  got=$(api GET "/branches/${branch}/protection")
+  got_admins=$(printf '%s' "$got" | jq -r '.enforce_admins.enabled')
+  got_linear=$(printf '%s' "$got" | jq -r '.required_linear_history.enabled')
+  got_contexts=$(printf '%s' "$got" | jq -r '.required_status_checks.contexts | join(",")')
+  if [[ "$got_admins" != "${EXPECT_ENFORCE_ADMINS[$branch]}" ]]; then
+    echo "� ${branch}: enforce_admins expected '${EXPECT_ENFORCE_ADMINS[$branch]}', got '${got_admins}'" >&2
+    return 1
+  fi
+  if [[ "$got_linear" != "${EXPECT_LINEAR[$branch]}" ]]; then
+    echo "✘ ${branch}: required_linear_history expected '${EXPECT_LINEAR[$branch]}', got '${got_linear}'" >&2
+    return 1
+  fi
+  if [[ "$got_contexts" != "${EXPECT_CONTEXTS[$branch]}" ]]; then
+    echo "✘ ${branch}: required contexts expected '${EXPECT_CONTEXTS[$branch]}', got '${got_contexts}'" >&2
+    return 1
+  fi
+  echo "  ✓ ${branch}: enforce_admins=${got_admins}, required_linear_history=${got_linear}, required_contexts=${got_contexts}"
+}
+
+for branch in "${BRANCHES[@]}"; do
+  body="$main_body"
+  [[ "$branch" == "develop" ]] && body="$develop_body"
+  echo "→ Applying protection to ${OWNER}/${REPO}@${branch}"
+  api PUT "/branches/${branch}/protection" "$body" >/dev/null
+  verify "$branch"
+done
+
+echo "✔ Branch protection applied and verified on main and develop."

--- a/scripts/merge-strategy.sh
+++ b/scripts/merge-strategy.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# merge-strategy.sh — apply the hybrid merge strategy from
+# CONTRIBUTING.md "Merge strategy — hybrid, on purpose" to the repo via
+# the GitHub REST API. Requires a token with admin rights on the repo.
+#
+# Usage:
+#   GITHUB_TOKEN=ghp_xxx bash scripts/merge-strategy.sh
+#
+# Idempotent: running twice produces the same state. Safe to re-run
+# after CONTRIBUTING.md changes the ruleset.
+#
+# Why a script: the ruleset is the single source of truth in
+# CONTRIBUTING.md. This script encodes that table so the settings can
+# be reproduced by any maintainer without copy-pasting from the docs.
+# Issue #29.
+
+set -euo pipefail
+
+OWNER="${OWNER:-Team-Centinela}"
+REPO="${REPO:-Project-save-me-of-the-riwi}"
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN is required (admin scope)." >&2
+  exit 2
+fi
+
+body='{
+  "allow_squash_merge": true,
+  "allow_merge_commit": true,
+  "allow_rebase_merge": false,
+  "allow_auto_merge": true,
+  "delete_branch_on_merge": true,
+  "squash_merge_commit_title": "PR_TITLE",
+  "squash_merge_commit_message": "PR_BODY"
+}'
+
+echo "→ Applying merge settings to ${OWNER}/${REPO}"
+gh api \
+  --method PATCH \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/${OWNER}/${REPO}" \
+  --input - <<<"$body" >/dev/null
+
+echo "✔ Merge settings applied: squash+merge-commit enabled, rebase disabled, auto-merge on, head branches auto-deleted, squash uses PR title + body."

--- a/src/config/env.spec.ts
+++ b/src/config/env.spec.ts
@@ -28,6 +28,15 @@ describe('config/env', () => {
   });
 
   it('throws when VITE_TMDB_READ_TOKEN is missing', async () => {
+    // Stub explicitly with empty string: vi.unstubAllEnvs() (in
+    // beforeEach above) only restores values that were stubbed by
+    // vi.stubEnv, so a real CI secret in process.env would survive
+    // unstub and make this test pass-through (resolves with the
+    // secret instead of rejecting). Stubbing with '' is semantically
+    // equivalent to "missing" here because Zod's z.string().min(40)
+    // rejects the empty string with the same "Invalid environment
+    // configuration" error the test asserts on.
+    vi.stubEnv('VITE_TMDB_READ_TOKEN', '');
     await expect(import('./env')).rejects.toThrow(/Invalid environment configuration/);
   });
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,6 +13,28 @@ vi.stubEnv('VITE_TMDB_READ_TOKEN', 'a'.repeat(64));
 // `onUnhandledRequest: 'error'` is what makes MSW useful: a request that
 // nobody simulated blows up the test instead of going to the real network.
 beforeAll(() => {
+  // Node 25+ ships a built-in `localStorage` global as part of the
+  // Web Storage API. With v25.0.0 the global is unflagged (v22 only
+  // exposes it behind `--experimental-webstorage`; v26 will throw a
+  // DOMException instead of returning an empty object). When
+  // `--localstorage-file` is not provided to a valid path on v25,
+  // the global is an empty stub object with no methods
+  // (`setItem`/`getItem`/`clear`/etc. are all `undefined`). Vitest's
+  // `populateGlobal` walks the jsdom window and only assigns keys that
+  // are NOT already on `global` (or are in its allow-list); since
+  // `localStorage` is neither, vitest skips it and Node's stub wins.
+  // Every spec that touches `window.localStorage` then explodes with
+  // "localStorage.clear is not a function". Replacing the stub with
+  // jsdom's real Storage at file setup restores the expected behaviour
+  // and is a no-op on Node versions where `localStorage` is undefined.
+  const jsdomInstance = (globalThis as { jsdom?: { window: { localStorage: Storage } } }).jsdom;
+  if (jsdomInstance) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: jsdomInstance.window.localStorage,
+      writable: true,
+      configurable: true,
+    });
+  }
   server.listen({ onUnhandledRequest: 'error' });
 });
 afterEach(async () => {


### PR DESCRIPTION
## Description

First release-style merge from `develop` to `main`. Lands the governance rollout that closes #27, #28, #29, #30:

- **#94** — `chore(governance): split squash commit fields and apply hybrid merge settings` — repo-level merge settings: rebase disabled, auto-merge on, head branches auto-deleted, squash uses `PR_TITLE` + `PR_BODY`. Settings applied via `scripts/merge-strategy.sh`.
- **#92** — `fix(test): restore jsdom localStorage under Node 25+ empty stub` — localStorage runtime workaround so contributors on Node ≥ 25 don't see the 590-failure cascade when the stub overrides jsdom.
- **#89** — `docs(github): add branch naming reminder to PR template` — Branch Naming section in `.github/pull_request_template.md`.
- **#93** — `docs(governance): document, verify, and apply branch protection rules` — long-lived-branch protection (PR + 1 review + `Quality gate` + dismiss-stale + conversation resolution + no linear history + no force pushes + no deletions) with the `Include administrators` asymmetry (`main` enforces, `develop` does not). Includes the post-apply verification step in `scripts/branch-protection.sh` that catches drift between the JSON payload and the live ruleset.

### Merge strategy

Per `CONTRIBUTING.md` § "Merge strategy — hybrid, on purpose": `release/* → main` uses **Create a merge commit**, not Squash. The release branch carries the two-parent commit into `main` so the future `main → develop` reverse merge keeps a real shared ancestor and does not produce phantom conflicts (see the rationale walkthrough in CONTRIBUTING.md lines 82–93).

A follow-up PR from `release/governance-rollout` back into `develop` will land the second half of the round-trip with the same merge-commit strategy. That second PR is **required** — without it, the next reverse merge will carry the same phantom-conflict risk the round-trip exists to avoid.

### Why a release branch, not a direct `develop → main` PR

CONTRIBUTING.md § "Pull request process" step 5 mandates that `release/*` branches off `develop`, opens the release PR against `main`, and then opens a second PR from `release/*` back to `develop`. Following the rule keeps the merge-button choice (merge commit, not squash) unambiguous and makes the audit trail explicit: every commit on `main` is reachable from a release PR diff.

### Verification

- `bash scripts/verify.sh --full` green locally before push (91s): format, lint, types, tests (469/469, 91.3% statements / 84.62% branches), build, dependency check.
- Branch protection already live on `main` (`enforce_admins: true`): this PR requires 1 approval and the `Quality gate` check before merge.
- No source-code or spec changes ride along beyond the four PRs above.

## Type of Change

- [x] Chore / Maintenance (governance rollout)

## Branch Naming

- [x] `release/governance-rollout` follows the `release/vX.Y.Z` family in spirit (this rollout is pre-versioned; the next `release/v0.1.0` will follow the same shape).
- [x] Branch is lowercase, kebab-case.
- [x] Branched off `develop`.

## What Changed

- `CONTRIBUTING.md` — multiple sections updated: long-lived-branch protection column (no `linear history`); branch-protection settings table expanded to the full per-branch ruleset with `Quality gate` as the required check; squash commit split into title + message; back-links to #27, #28, #29.
- `scripts/branch-protection.sh` (new) — encodes the protection ruleset as JSON; apply-then-verify catches drift between payload and live.
- `scripts/merge-strategy.sh` (new) — encodes the hybrid merge settings as JSON; idempotent.
- `.github/pull_request_template.md` — Branch Naming section between Type of Change and What Changed.
- `vitest.setup.ts` — localStorage override before MSW listens (Node 25+ workaround; no-op on Node versions where the global is undefined).
- `src/config/env.spec.ts` — explicit empty-string stub in "throws when missing" so the test survives `vi.unstubAllEnvs()` not clearing real `process.env` entries (CI secret).

## Affected Layers

- [ ] `domain/` — pure TypeScript, no framework imports
- [ ] `application/` — use cases and ports
- [ ] `infrastructure/` — HTTP, storage, API
- [ ] `presentation/` — React, routes, hooks

## How to Test

1. Pull `release/governance-rollout` locally
2. `git log --first-parent main` after merge should show **one** line per release (the merge commit) — confirms `git log --first-parent` stays clean per the CONTRIBUTING.md rationale.
3. `git log --merges -n 1 main` should show this PR's merge commit with two parents — confirms `--no-ff` semantics.

## Tests

- [ ] I added unit tests for the new logic (N/A — governance rollout; behaviour covered by the 469 specs that already pass)
- [ ] I updated existing tests that no longer apply (none)
- [x] I verified the manual test plan above
- [x] Coverage has not decreased (91.3% statements / 84.62% branches — same as develop)

## Quality Gate

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm check-types` passes
- [x] `pnpm test` passes (469/469, coverage thresholds met)
- [x] `pnpm build` succeeds
- [x] `./scripts/check-versions.sh` reports no deprecated deps

Verified locally with `bash scripts/verify.sh --full` (91s, GREEN) before push.

## Checklist

- [x] My code follows the project's architecture rules (domain is pure, dependencies point inward)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious
- [x] I have updated the documentation (README, copy, etc.) if needed
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

None — governance + docs + tooling changes only. Production bundles unaffected.

## Reviewer Focus

- `@reviewer` please confirm the merge button is **Create a merge commit**, not Squash — squash breaks the `develop ↔ main` round-trip per CONTRIBUTING.md § "Why not squash everything?".
- After merging, please confirm the follow-up PR from `release/governance-rollout` back into `develop` lands with the same merge-commit strategy. That second PR is required to close the round-trip.

## Related issues

- Closes the rollout tracked by #27 (branch protection), #28 (branching model — closed via PR #89), #29 (hybrid merge strategy), #30 (Conventional Commits — closed via PR #37 docs).
- The follow-up tooling issue is #95 (`chore(gate): enforce Conventional Commits via @commitlint/cli + Husky commit-msg hook`).