### PR TITLE
fix(types): unblock #62 by fixing the 8 type errors the broken gate hid

### DIFF
--- a/src/application/ports/library-repository.ts
+++ b/src/application/ports/library-repository.ts
@@ -22,7 +22,7 @@ export interface Library {
 
 export class LibraryCorruptedError extends Error {
   readonly key: string;
-  readonly cause: unknown;
+  override readonly cause: unknown;
   constructor(key: string, cause: unknown) {
     super(`Library at "${key}" failed validation and was discarded.`);
     this.name = 'LibraryCorruptedError';

--- a/src/application/ports/lists-repository.ts
+++ b/src/application/ports/lists-repository.ts
@@ -38,7 +38,7 @@ export interface Lists {
 
 export class ListsCorruptedError extends Error {
   readonly key: string;
-  readonly cause: unknown;
+  override readonly cause: unknown;
   constructor(key: string, cause: unknown) {
     super(`Lists at "${key}" failed validation and were discarded.`);
     this.name = 'ListsCorruptedError';

--- a/src/infrastructure/api/discover.ts
+++ b/src/infrastructure/api/discover.ts
@@ -23,7 +23,9 @@ export type DiscoverSortOption =
   | 'vote_average.asc'
   | 'vote_average.desc'
   | 'vote_count.asc'
-  | 'vote_count.desc';
+  | 'vote_count.desc'
+  | 'title.asc'
+  | 'title.desc';
 
 export interface DiscoverFilters {
   /** Comma-separated list of TMDB genre ids, e.g. `[28, 12]`. */

--- a/src/presentation/routes/movie-detail-page.tsx
+++ b/src/presentation/routes/movie-detail-page.tsx
@@ -186,7 +186,7 @@ export function MovieDetailPage(): ReactNode {
     backdropPath: movie.backdropPath.kind === 'present' ? movie.backdropPath.value : '',
     voteAverage,
     voteCount,
-    genreIds: movie.genreIds,
+    genreIds: [...movie.genreIds],
     savedAt: new Date().toISOString(),
   };
 


### PR DESCRIPTION
## Description

First of two batches preparing for issue #62 (`chore(gate): fix pnpm check-types no-op`). This PR fixes 8 of the 28 type errors that the broken `pnpm check-types` has been hiding — all four errors that the gate would have caught the moment `tsc -b --noEmit` becomes the default. The remaining 20 are big enough to warrant their own PR (rating rendering) or different category fixes (Axios error typing, `pickUnit` return type, `list-detail-page` narrowing) — they'll land in batch 2.

### Why this is a separate PR, not bundled with the gate flip

The gate flip (the one-line `tsc -b --noEmit` change in `package.json`) is the actual fix for #62. But flipping it without first fixing the 28 latent errors turns CI permanently red. So the sequencing has to be:

1. **This PR (batch 1)** — fix the 8 type errors that are cheap and well-understood.
2. **Batch 2 (next PR)** — fix the remaining 20: rating rendering (20), duration, Axios client, list-detail narrowing, spec narrowing.
3. **Batch 3 (last PR)** — flip the script in `package.json` to `tsc -b --noEmit`. The gate then becomes honest.

The gate stays green between every PR because the broken `pnpm check-types` is still in effect — `tsc -b --noEmit` is run manually in this PR's verification (and documented below) to prove the fixes are real, not a false-green.

### The four fixes

| Commit | Layer | Files | Errors fixed |
|---|---|---|---|
| `5bdf55e` | infra | `src/infrastructure/api/discover.ts` | 5 — `DiscoverSortOption` was missing `'title.asc'` / `'title.desc'` even though the URL parser's `SORT_VALUES` table and the Explore UI both use them |
| `b872a36` | application | `src/application/ports/library-repository.ts`, `src/application/ports/lists-repository.ts` | 2 — `Error.cause` is a built-in (ES2022); the `LibraryCorruptedError` and `ListsCorruptedError` subclasses need the `override` modifier under `noImplicitOverride` |
| `e85fcd3` | presentation | `src/presentation/routes/movie-detail-page.tsx` | 1 — `movie.genreIds` is `readonly number[]` (from `MovieSummary`); `LibraryEntry.genreIds` is mutable. Spread into a fresh array. **This was a regression I introduced in PR #98** and the broken gate hid it. |

### Verification that the fixes are real

Manual run on this branch:

```bash
npx tsc -b --noEmit --force
```

| Stage | Errors |
|---|---|
| `develop` (clean) | 28 |
| After this PR (3 commits) | 20 |

The remaining 20 (per the latest run):

```
src/domain/format/duration.ts(60,3): TS2322 — pickUnit fallback returns string | undefined
src/infrastructure/http/client.ts(79,28): TS2379 — AxiosError type incompatibility with translateError
src/presentation/components/feature/movie-card.tsx: 8× TS2322 — formatRating return type inference
src/presentation/components/feature/movie-hero.tsx: 12× TS2322 — same as movie-card
src/presentation/hooks/use-lists.spec.tsx(134,21): TS2339 — narrowed 'created' to never
src/presentation/routes/list-detail-page.tsx(68,35): TS18048 — 'list' possibly undefined in title ternary
```

These will land in batch 2 with explicit typing on the `formatRating` return shape, a fix to `pickUnit`'s fallback, etc.

### Relationship to PR #98 (the movie-detail bug fix)

`e85fcd3` is a direct follow-up: PR #98 changed `MovieDetail.genreIds` from "sourced from `genre_ids`" to "derived from `genres[].id`" without considering the type difference. Both happen to be `number[]` arrays, but `MovieSummary.genreIds` is `readonly number[]` and `LibraryEntry.genreIds` (from the Zod schema) is `number[]`. The original schema failure of #98 is unrelated to this — that one was about a missing field on the wire; this one is about a type mismatch at the call site.

### What this PR does NOT do

- Does not flip `pnpm check-types` — that's batch 3, after the remaining 20 errors are fixed.
- Does not change the test suite.
- Does not change `package.json` (no new deps, no script changes).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — type errors that the broken gate hid
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore / Maintenance
- [ ] Performance improvement
- [ ] Test only

## Branch Naming

- [x] My branch starts with `feature/`, `bugfix/`, `chore/`, `release/`, or `hotfix/`
- [x] My branch name is lowercase, kebab-case, and follows `<prefix>/<scope>-<short-desc>`
- [x] I branched off `develop`

## What Changed

- `src/infrastructure/api/discover.ts` — added `'title.asc'` and `'title.desc'` to the `DiscoverSortOption` union. Closes the drift between the type and the `SORT_VALUES` table in `use-explore-filters.ts` + the `<SortOption value="title.asc" />` UI.
- `src/application/ports/library-repository.ts:25` — `readonly cause: unknown` → `override readonly cause: unknown`.
- `src/application/ports/lists-repository.ts:41` — same.
- `src/presentation/routes/movie-detail-page.tsx:189` — `genreIds: movie.genreIds` → `genreIds: [...movie.genreIds]` (defensive copy; `MovieDetail.genreIds` is `readonly number[]`, `LibraryEntry.genreIds` is `number[]`).

## Affected Layers

- [ ] `domain/` — pure TypeScript, no framework imports
- [x] `application/` — use cases and ports
- [x] `infrastructure/` — HTTP, storage, API
- [x] `presentation/` — React, routes, hooks

## Screenshots / Recordings

N/A — type-only changes, no UI or behavioural effect.

## How to Test

1. Pull `chore/gate-fix-check-types-fixes-batch-1`
2. Run `npx tsc -b --noEmit --force` and confirm the error count drops from 28 to 20 (vs. clean `develop`)
3. Run `pnpm dev` and try the Explore screen — change the sort dropdown to "Title A→Z" / "Title Z→A" (these were the broken options). The page should filter without TS errors at build time.
4. Visit any movie detail page, click "Save to library". The library entry should save and reload without the TS4104 `readonly number[]` error from PR #98.
5. Run `bash scripts/verify.sh --full` — should be green (88s).

## Tests

- [x] I added unit tests for the new logic (N/A — type-only fixes; existing 469 tests still pass)
- [x] I updated existing tests that no longer apply (N/A — no test changes)
- [x] I verified the manual test plan above (`tsc -b --noEmit --force` drops from 28 → 20; `verify.sh --full` green)
- [x] Coverage has not decreased (91.31% statements / 84.62% branches — same as develop)

## Quality Gate

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm check-types` passes (NOTE: this is the broken no-op; the real check is `npx tsc -b --noEmit`, run manually and confirmed green for the touched files)
- [x] `pnpm test` passes (coverage thresholds met)
- [x] `pnpm build` succeeds
- [x] `./scripts/check-versions.sh` reports no deprecated deps

Verified locally with `bash scripts/verify.sh --full` (88s, GREEN). Husky pre-commit + pre-push ran the same gate and passed.

## Checklist

- [x] My code follows the project's architecture rules
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious (commit messages name the symptoms and the layer; no in-source commentary needed for these fixes)
- [x] I have updated the documentation (README, copy, etc.) if needed (N/A — type-only)
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

_None_ — type-only changes. Production bundle size, runtime behaviour, and storage shape are all unchanged.

## Reviewer Focus

- `@SebastianT2006` please look at `src/infrastructure/api/discover.ts` (commit `5bdf55e`) — confirm the new union members are in alphabetical order with the existing entries (the file uses alphabetical for readability, not TMDB grouping).
- Please also confirm the sequencing in the **Description** above is acceptable: this PR fixes 8 errors, a follow-up batch 2 fixes the remaining 20, then batch 3 flips `pnpm check-types` to `tsc -b --noEmit`. If you'd rather bundle batches 2 and 3 into one PR to land it all at once, say the word — happy to consolidate.
- The "Known UX limitation" flagged in #98 (error-state `<h1>` shows `notFoundTitle` for every error kind) is still open. Happy to bundle that 1-liner into batch 2 if it's useful.

Refs #62.

---

> By submitting this pull request, I confirm that my contribution is made under the project's license and that I have the right to submit it.