### PR TITLE
chore(test): keep the MSW detail fixture true to /movie/{id}

### DIFF
--- a/src/test/msw/tmdb-handlers.ts
+++ b/src/test/msw/tmdb-handlers.ts
@@ -53,10 +53,13 @@ export const TMDB_MOVIE_SUMMARY_FIXTURE = {
 
 // The detail endpoint returns full `genres` objects, not the
 // numeric `genre_ids` array (that field is reserved for the
-// summary endpoints — see PR #98). Destructuring keeps the
-// detail fixture from inheriting a field `/movie/{id}` never
-// sends; each fixture mirrors its own endpoint's shape.
-const { genre_ids: _genreIds, ...summaryShape } = TMDB_MOVIE_SUMMARY_FIXTURE;
+// summary endpoints — see PR #98). Omitting it keeps the detail
+// fixture from inheriting a field `/movie/{id}` never sends;
+// each fixture mirrors its own endpoint's shape.
+const summaryShape: Omit<typeof TMDB_MOVIE_SUMMARY_FIXTURE, 'genre_ids'> = {
+  ...TMDB_MOVIE_SUMMARY_FIXTURE,
+};
+delete summaryShape.genre_ids;
 
 export const TMDB_MOVIE_DETAIL_FIXTURE = {
   ...summaryShape,

--- a/src/test/msw/tmdb-handlers.ts
+++ b/src/test/msw/tmdb-handlers.ts
@@ -51,8 +51,15 @@ export const TMDB_MOVIE_SUMMARY_FIXTURE = {
   genre_ids: [28, 12, 878],
 };
 
+// The detail endpoint returns full `genres` objects, not the
+// numeric `genre_ids` array (that field is reserved for the
+// summary endpoints — see PR #98). Destructuring keeps the
+// detail fixture from inheriting a field `/movie/{id}` never
+// sends; each fixture mirrors its own endpoint's shape.
+const { genre_ids: _genreIds, ...summaryShape } = TMDB_MOVIE_SUMMARY_FIXTURE;
+
 export const TMDB_MOVIE_DETAIL_FIXTURE = {
-  ...TMDB_MOVIE_SUMMARY_FIXTURE,
+  ...summaryShape,
   tagline: 'Your mind is the scene of the crime.',
   runtime: 148,
   genres: [

--- a/src/test/msw/tmdb-handlers.ts
+++ b/src/test/msw/tmdb-handlers.ts
@@ -53,13 +53,15 @@ export const TMDB_MOVIE_SUMMARY_FIXTURE = {
 
 // The detail endpoint returns full `genres` objects, not the
 // numeric `genre_ids` array (that field is reserved for the
-// summary endpoints — see PR #98). Omitting it keeps the detail
-// fixture from inheriting a field `/movie/{id}` never sends;
-// each fixture mirrors its own endpoint's shape.
-const summaryShape: Omit<typeof TMDB_MOVIE_SUMMARY_FIXTURE, 'genre_ids'> = {
-  ...TMDB_MOVIE_SUMMARY_FIXTURE,
-};
-delete summaryShape.genre_ids;
+// summary endpoints — see PR #98). Destructuring-rest drops
+// `genre_ids` so the detail fixture does not inherit a field
+// `/movie/{id}` never sends; each fixture mirrors its own
+// endpoint's shape.
+const {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentionally discarded: /movie/{id} never returns genre_ids
+  genre_ids: _discardedGenreIds,
+  ...summaryShape
+} = TMDB_MOVIE_SUMMARY_FIXTURE;
 
 export const TMDB_MOVIE_DETAIL_FIXTURE = {
   ...summaryShape,


### PR DESCRIPTION
## Description

Follow-up from the #98 review: `TMDB_MOVIE_DETAIL_FIXTURE` was built by spreading `TMDB_MOVIE_SUMMARY_FIXTURE`, which dragged the numeric `genre_ids` array into a fixture served for `/movie/{id}` — a field that endpoint never returns (verified live in the #98 review). The file header claims these fixtures "mirror the shape TMDB actually returns"; now they actually do, per endpoint.

The change is inert today (Zod strips unknown keys), but it removes the last copy of the invented shape so a future `.strict()` schema or fixture-shape assertion cannot silently validate an invented response again.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Chore / Maintenance (test tooling only)
- [ ] Performance
- [ ] Test only

## What Changed

- `src/test/msw/tmdb-handlers.ts` — the detail fixture now omits `genre_ids` (destructuring-rest on the spread copy), with a comment naming the endpoint asymmetry and PR #98.

## Affected Layers

- [ ] `domain/`
- [ ] `application/`
- [ ] `infrastructure/`
- [ ] `presentation/`
- [x] `test/`

## How to Test

1. Pull `chore/test-msw-detail-fixture-shape`
2. `grep -n "genre_ids" src/test/msw/tmdb-handlers.ts` — appears only in the summary fixture and comments.
3. `pnpm test` — 485 tests green; presentation-level specs exercise the detail handler without any behaviour change.

## Tests

- [x] No new tests needed — fixtures only; the full suite is the regression check.
- [x] Coverage has not decreased (no source touched).

## Quality Gate

- [x] `pnpm format:check`
- [x] `pnpm lint` (zero warnings)
- [x] `pnpm check-types`
- [x] `pnpm test` (58 files / 485 tests)
- [x] `pnpm build`
- [x] `./scripts/check-versions.sh`

## Deployment Notes

None — test fixtures only; no env vars, no migrations, no config toggles, no runtime behaviour change.

Refs #98