### PR TITLE
chore(presentation): polish pass on edit page and ConfirmDialog

### DIFF
--- a/src/presentation/components/ui/confirm-dialog.tsx
+++ b/src/presentation/components/ui/confirm-dialog.tsx
@@ -128,9 +128,9 @@ export function ConfirmDialog({
         <h2 id={titleId} className="text-lg font-semibold text-ink">
           {title}
         </h2>
-        <p id={bodyId} className="text-sm text-ink-muted">
+        <div id={bodyId} className="text-sm text-ink-muted">
           {body}
-        </p>
+        </div>
         <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <button
             ref={cancelRef}

--- a/src/presentation/components/ui/confirm-dialog.tsx
+++ b/src/presentation/components/ui/confirm-dialog.tsx
@@ -26,7 +26,7 @@ import { copy } from '@/presentation/copy/strings';
 export interface ConfirmDialogProps {
   readonly open: boolean;
   readonly title: string;
-  readonly body: string;
+  readonly body: ReactNode;
   readonly confirmLabel: string;
   /** Accessible name for the confirm button; names what will be destroyed. */
   readonly confirmAriaLabel?: string;
@@ -36,8 +36,13 @@ export interface ConfirmDialogProps {
 }
 
 function focusables(container: HTMLElement): HTMLElement[] {
+  // Scope: a confirm dialog's own controls (two buttons today).
+  // The selector still honours any focusable the parent renders
+  // into these slots, including `[tabindex]`-enabled elements.
   return Array.from(
-    container.querySelectorAll<HTMLElement>('button:not([disabled]), [href], input, textarea'),
+    container.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])',
+    ),
   );
 }
 
@@ -57,6 +62,14 @@ export function ConfirmDialog({
   const cancelRef = useRef<HTMLButtonElement | null>(null);
   // The element to restore focus to when the dialog closes.
   const restoreFocusRef = useRef<HTMLElement | null>(null);
+  // Stashed so the keydown listener below can depend on `[open]`
+  // alone: parents typically pass an inline `onCancel`, and a dep
+  // on the prop itself would re-attach the document listener on
+  // every parent render while the dialog is open.
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -76,7 +89,7 @@ export function ConfirmDialog({
     function handleKeyDown(event: KeyboardEvent): void {
       if (event.key === 'Escape') {
         event.stopPropagation();
-        onCancel();
+        onCancelRef.current();
         return;
       }
       if (event.key !== 'Tab' || dialogRef.current === null) return;
@@ -97,7 +110,7 @@ export function ConfirmDialog({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [open, onCancel]);
+  }, [open]);
 
   if (!open) return null;
 

--- a/src/presentation/routes/list-detail-page.spec.tsx
+++ b/src/presentation/routes/list-detail-page.spec.tsx
@@ -171,11 +171,23 @@ describe('ListDetailPage', () => {
   it('opens a confirmation dialog instead of deleting when the delete button is clicked', async () => {
     const user = userEvent.setup();
     seedListAndLibrary();
-    renderAt();
+    const { container } = renderAt();
     await user.click(await screen.findByRole('button', { name: copy.lists.remove }));
     const dialog = screen.getByRole('alertdialog');
     expect(dialog).toBeInTheDocument();
-    expect(dialog).toHaveTextContent(copy.lists.removeConfirm);
+    // Regression net for the `<p>`-wrapper / nested-`<p>` bug:
+    // the description target must contain both lines of the
+    // multi-paragraph body, not just the first one. If the
+    // wrapper starts as `<p>` again the HTML parser auto-closes
+    // it and `aria-describedby` ends up pointing at an empty
+    // element — this assertion catches that at the spec level.
+    const describedById = dialog.getAttribute('aria-describedby');
+    expect(describedById).not.toBeNull();
+    if (describedById === null) throw new Error('aria-describedby should be set');
+    const target = container.querySelector(`#${describedById}`);
+    expect(target).toBeInstanceOf(HTMLDivElement);
+    expect(target).toHaveTextContent(copy.lists.removeConfirm);
+    expect(target).toHaveTextContent(copy.lists.deleteDialogBody);
     // Nothing was deleted while the dialog is open.
     expect(window.localStorage.getItem('cineteca:lists:v1')).not.toBeNull();
     expect(

--- a/src/presentation/routes/list-detail-page.tsx
+++ b/src/presentation/routes/list-detail-page.tsx
@@ -166,24 +166,26 @@ export function ListDetailPage(): ReactNode {
               {copy.lists.moviesCount(inListEntries.length)}
             </p>
           </div>
-          <Link
-            to={`/my-lists/${id}/edit`}
-            className="inline-flex min-h-touch items-center justify-center rounded-card border border-ink-muted/30 px-5 text-sm font-medium text-ink transition-colors hover:border-ink-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
-          >
-            {copy.lists.editTitle}
-          </Link>
-          <button
-            type="button"
-            onClick={() => {
-              setConfirmOpen(true);
-            }}
-            disabled={lists.isRemoving}
-            aria-label={copy.lists.remove}
-            aria-haspopup="dialog"
-            className="inline-flex min-h-touch items-center justify-center rounded-card border border-danger/40 px-5 text-sm font-medium text-danger transition-opacity hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
-          >
-            {copy.lists.remove}
-          </button>
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              to={`/my-lists/${id}/edit`}
+              className="inline-flex min-h-touch items-center justify-center rounded-card border border-ink-muted/30 px-5 text-sm font-medium text-ink transition-colors hover:border-ink-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+            >
+              {copy.lists.editTitle}
+            </Link>
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmOpen(true);
+              }}
+              disabled={lists.isRemoving}
+              aria-label={copy.lists.remove}
+              aria-haspopup="dialog"
+              className="inline-flex min-h-touch items-center justify-center rounded-card border border-danger/40 px-5 text-sm font-medium text-danger transition-opacity hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+            >
+              {copy.lists.remove}
+            </button>
+          </div>
         </div>
       </header>
 
@@ -261,7 +263,12 @@ export function ListDetailPage(): ReactNode {
       <ConfirmDialog
         open={confirmOpen}
         title={copy.lists.deleteDialogTitle}
-        body={`${copy.lists.removeConfirm} ${copy.lists.deleteDialogBody}`}
+        body={
+          <>
+            <p>{copy.lists.removeConfirm}</p>
+            <p>{copy.lists.deleteDialogBody}</p>
+          </>
+        }
         confirmLabel={copy.lists.remove}
         confirmAriaLabel={`${copy.lists.remove}: ${list.name}`}
         onConfirm={() => {

--- a/src/presentation/routes/list-edit-page.tsx
+++ b/src/presentation/routes/list-edit-page.tsx
@@ -42,18 +42,16 @@ export function ListEditPage(): ReactNode {
     list !== undefined ? `${copy.lists.editTitle}: ${list.name}` : copy.lists.editTitle,
   );
 
-  const current = list;
-
   const handleSubmit = useCallback(
     async (values: ListFormValues): Promise<void> => {
-      if (id === null || current === undefined) return;
+      if (id === null || list === undefined) return;
       setErrorMessage(undefined);
       try {
         // The repository owns `updatedAt`; a no-op (the list was
         // deleted in another tab) resolves with `undefined` per
         // the port contract and is surfaced as an error.
         const updated = await lists.update({
-          ...current,
+          ...list,
           name: values.name.trim(),
           description: values.description.trim(),
         });
@@ -64,10 +62,10 @@ export function ListEditPage(): ReactNode {
         setErrorMessage(copy.lists.errorEdit);
       }
     },
-    [current, id, lists, navigate],
+    [list, id, lists, navigate],
   );
 
-  if (id === null || (!lists.isLoading && current === undefined)) {
+  if (id === null || (!lists.isLoading && list === undefined)) {
     return (
       <section aria-labelledby="list-edit-not-found-title">
         <h1 id="list-edit-not-found-title" className="text-3xl font-semibold text-ink">
@@ -80,7 +78,7 @@ export function ListEditPage(): ReactNode {
     );
   }
 
-  if (lists.isLoading || current === undefined) {
+  if (lists.isLoading || list === undefined) {
     return (
       <section aria-busy="true" aria-label={copy.lists.detailLoadingAria}>
         <h1 className="text-3xl font-semibold text-ink">{copy.lists.editTitle}</h1>
@@ -102,7 +100,7 @@ export function ListEditPage(): ReactNode {
       </header>
       <ListForm
         mode="edit"
-        defaultValues={{ name: current.name, description: current.description }}
+        defaultValues={{ name: list.name, description: list.description }}
         onSubmit={(values) => handleSubmit(values)}
         onCancel={() => {
           void navigate(`/my-lists/${id}`);


### PR DESCRIPTION
## Description

**Blocker fixed** (re-requested review from @3105jero).

`#99` introduced `body: ReactNode` on `ConfirmDialog`, and the delete caller now passes a fragment of two `<p>` elements. The body wrapper on the dialog stayed `<p>`, producing `<p><p>…</p><p>…</p></p>` — invalid HTML. React 19 itself flags the hydration error; in real browsers the parser auto-closes the outer `<p>`, leaving `aria-describedby` pointing at an empty element so screen readers announce the alertdialog with **no description**.

- `confirm-dialog.tsx`: body wrapper `<p>` → `<div>` (no content-model restrictions; `aria-describedby` works on any element). The single-paragraph case is unaffected.
- `list-detail-page.spec.tsx`: regression assertion — the `aria-describedby` target is an HTMLDivElement and contains both copy lines, so the wrapper can't silently regress to `<p>`.

**Bug independently reproduced in jsdom before the fix** — React 19's own hydration warning confirmed:

```
<p> cannot contain a nested <p>.
This will cause a hydration error.
```

…and absent after.

## Non-blocking review notes

The four polish items from the prior review were already landed (`current` alias removed, `onCancel` ref-stashed, `focusables` widened and documented, Edit+Delete grouped). The destructuring-rest nit on `tmdb-handlers.ts` was the other branch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Performance
- [ ] Test only

## What Changed

- `src/presentation/components/ui/confirm-dialog.tsx` — body wrapper `<p>` → `<div>`.
- `src/presentation/routes/list-detail-page.spec.tsx` — regression assertion on the description target.

## Affected Layers

- [ ] `domain/`
- [ ] `application/`
- [ ] `infrastructure/`
- [x] `presentation/`

## How to Test

1. Pull `chore/presentation-dialog-polish`
2. `pnpm test` — 485 tests green; no React 19 hydration warnings.
3. Open `/my-lists/:id` → Delete → inspect the alertdialog. `aria-describedby` resolves to a `<div>` containing both copy lines.

## Quality Gate

- [x] `pnpm format:check`
- [x] `pnpm lint` (zero warnings)
- [x] `pnpm check-types`
- [x] `pnpm test` (58 files / 485 tests, no hydration warnings)
- [x] `pnpm build`
- [x] `./scripts/check-versions.sh`
