### PR TITLE
chore(test): drop redundant cleanup() call (auto-handled by @testing-library/react@16)

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { server } from './src/test/msw/server';
 
@@ -51,7 +50,6 @@ afterEach(async () => {
   if (typeof window !== 'undefined' && window.localStorage !== undefined) {
     window.localStorage.clear();
   }
-  cleanup();
 });
 afterAll(() => {
   server.close();


### PR DESCRIPTION
## Description

Removes the dead `cleanup()` call and its now-unused import from `vitest.setup.ts`. `@testing-library/react@16.x` registers its own `afterEach(() => cleanup())` at import time (see `node_modules/@testing-library/react/dist/index.js:27`, guarded by `RTL_SKIP_AUTO_CLEANUP`), so the explicit call was a no-op second-cleanup. The redundant `import { cleanup } from '@testing-library/react'` line went with it.

Closes #48 — surfaced in the PR #45 review (item 4: *"future readers will wonder about it"*).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Chore / Maintenance (test tooling)
- [ ] Performance
- [ ] Test only

## Branch Naming

- [x] My branch starts with `feature/`, `bugfix/`, `chore/`, `release/`, or `hotfix/`
- [x] My branch name is lowercase, kebab-case, and follows `<prefix>/<scope>-<short-desc>` (no issue number in the name)
- [x] I branched off `develop`

## What Changed

- `vitest.setup.ts` — removed `import { cleanup } from '@testing-library/react';` and the trailing `cleanup();` from the shared `afterEach`. Net diff: **2 lines deleted**, 0 lines added, 0 behaviour change.

## Affected Layers

- [ ] `domain/` — pure TypeScript, no framework imports
- [ ] `application/` — use cases and ports
- [ ] `infrastructure/` — HTTP, storage, API
- [ ] `presentation/` — React, routes, hooks
- [x] `test/` — vitest setup, fixtures, msw

## Screenshots / Recordings

### Before / After

N/A — test-environment behaviour; covered by the suite itself.

## How to Test

1. Pull `chore/test-remove-redundant-cleanup`
2. Run `bash scripts/verify.sh --full`
3. Confirm `Tests  485 passed (485)` and no `Test Files  failed`
4. (Sanity) `grep -n "cleanup" vitest.setup.ts` — no matches beyond the `cleanup:` style in the unchanged matchMedia comment.

## Tests

- [ ] I added unit tests for the new logic (N/A — deletion; behaviour covered by the 485 specs that still pass)
- [x] I updated existing tests that no longer apply (none)
- [x] I verified the manual test plan above
- [x] Coverage has not decreased (no source touched; coverage unchanged)

## Quality Gate

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm check-types` passes
- [x] `pnpm test` passes (485/485, coverage thresholds met)
- [x] `pnpm build` succeeds
- [x] `./scripts/check-versions.sh` reports no deprecated deps

Verified locally with `bash scripts/verify.sh --full` (86 s, GREEN).

## Checklist

- [x] My code follows the project's architecture rules (domain is pure, dependencies point inward)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious (none added — deletion only)
- [x] I have updated the documentation (README, copy, etc.) if needed (N/A — setup file, comments above the call already explained why)
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

_None_ — test-environment only. No env vars, no migrations, no config toggles, no runtime bundle change.

## Reviewer Focus

- `@reviewer` please look at `vitest.setup.ts` lines 1–3 (the trimmed import line) and line 49 (where `cleanup();` used to live, now empty). Behaviour proof: the library's auto-cleanup is in `node_modules/@testing-library/react/dist/index.js:27`, registered on first import of `@testing-library/react` and idempotent with our removed call.

Closes #48