### PR TITLE
fix(routes): pass Vite base as router basename so Pages deployment renders home

### DIFF
--- a/src/presentation/routes/router.spec.tsx
+++ b/src/presentation/routes/router.spec.tsx
@@ -10,13 +10,13 @@ import { AppProviders } from '@/presentation/providers/app-providers';
 import { copy } from '../copy/strings';
 import { router } from './router';
 
-function renderRouterAt(path: string) {
+function renderRouterAt(path: string, basename = '/') {
   // Same route shape as `router`, but rebuilt on a memory history so the test
   // can drive navigation without touching the browser URL. The AppProviders
   // wrapper is needed because HomePage, SearchPage, ExplorePage, and
   // MovieDetailPage all use TanStack Query hooks.
   const routes = router.routes as RouteObject[];
-  const memoryRouter = createMemoryRouter(routes, { initialEntries: [path] });
+  const memoryRouter = createMemoryRouter(routes, { basename, initialEntries: [path] });
   return render(
     <AppProviders>
       <RouterProvider router={memoryRouter} />
@@ -42,5 +42,17 @@ describe('router', () => {
     expect(screen.getByRole('link', { name: copy.brand })).toBeInTheDocument();
     // The TMDB attribution is in the footer.
     expect(screen.getByText(/not endorsed or certified by TMDB/i)).toBeInTheDocument();
+  });
+
+  it('matches "/" under a basename, as on GitHub Pages project sites', () => {
+    // Mirrors the deployment: the browser pathname is /<repo>/ but the route
+    // tree is rooted at "/". Without the basename this renders NotFoundPage.
+    renderRouterAt('/cineteca/', '/cineteca');
+    expect(screen.getByRole('heading', { name: /trending this week/i })).toBeInTheDocument();
+  });
+
+  it('resolves links against the basename, not the origin root', () => {
+    renderRouterAt('/cineteca/', '/cineteca');
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/cineteca');
   });
 });

--- a/src/presentation/routes/router.tsx
+++ b/src/presentation/routes/router.tsx
@@ -30,21 +30,28 @@ import { NotFoundPage } from './not-found-page';
 import { RootLayout } from './root-layout';
 import { SearchPage } from './search-page';
 
-export const router = createBrowserRouter([
-  {
-    path: '/',
-    Component: RootLayout,
-    children: [
-      { index: true, Component: HomePage },
-      { path: 'explore', Component: ExplorePage },
-      { path: 'search', Component: SearchPage },
-      { path: 'movie/:id', Component: MovieDetailPage },
-      { path: 'my-cineteca', Component: LibraryPage },
-      { path: 'my-lists', Component: ListsPage },
-      { path: 'my-lists/new', Component: ListCreatePage },
-      { path: 'my-lists/:listId', Component: ListDetailPage },
-      { path: 'my-lists/:listId/edit', Component: ListEditPage },
-      { path: '*', Component: NotFoundPage },
-    ],
-  },
-]);
+// The basename comes from Vite's `base` (see vite.config.ts): '/' in dev,
+// '/<repo>/' on GitHub Pages. Without it the router would try to match the
+// full pathname including the repo prefix and every visit would land on
+// the wildcard NotFoundPage.
+export const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      Component: RootLayout,
+      children: [
+        { index: true, Component: HomePage },
+        { path: 'explore', Component: ExplorePage },
+        { path: 'search', Component: SearchPage },
+        { path: 'movie/:id', Component: MovieDetailPage },
+        { path: 'my-cineteca', Component: LibraryPage },
+        { path: 'my-lists', Component: ListsPage },
+        { path: 'my-lists/new', Component: ListCreatePage },
+        { path: 'my-lists/:listId', Component: ListDetailPage },
+        { path: 'my-lists/:listId/edit', Component: ListEditPage },
+        { path: '*', Component: NotFoundPage },
+      ],
+    },
+  ],
+  { basename: import.meta.env.BASE_URL },
+);


### PR DESCRIPTION
## Description

Closes #108

On the GitHub Pages project site (`https://team-centinela.github.io/Project-save-me-of-the-riwi/`) the app shell loaded fine (Vite `base` + the `404.html` SPA fallback in `deploy.yml` both work), but **every visit rendered the 404 view** and every link escaped to the org root, where a hard refresh hits GitHub's own 404 page.

Root cause: `createBrowserRouter` was called without a `basename`, so React Router matched routes against the full pathname (`/Project-save-me-of-the-riwi/...`), which never matches any route — the wildcard `NotFoundPage` won. Verified live with Playwright against the production URL before the fix (see issue for details).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Branch Naming

- [x] My branch starts with `feature/`, `bugfix/`, `chore/`, `release/`, or `hotfix/`
- [x] My branch name is lowercase, kebab-case, and follows `<prefix>/<scope>-<short-desc>` (no issue number in the name)
- [x] I branched off `develop` (or off `main` for `hotfix/` and `release/`)

## What Changed

- _`src/presentation/routes/router.tsx`_ — pass `{ basename: import.meta.env.BASE_URL }` as the second argument to `createBrowserRouter`. `import.meta.env.BASE_URL` mirrors Vite's `base` from `vite.config.ts`: `/` in dev, `/<repo>/` on Pages. No new env vars, no config plumbing.
- _`src/presentation/routes/router.spec.tsx`_ — two regression specs: routes match `/` under a `/cineteca` basename, and `<Link to="/">` resolves against the basename (`/cineteca`), not the origin root.

## Affected Layers

- [x] `presentation/` — React, routes, hooks

## Screenshots / Recordings

### Before

Opening `https://team-centinela.github.io/Project-save-me-of-the-riwi/` renders "404 – Page not found"; nav links point to `https://team-centinela.github.io/explore`, etc. (org root).

### After

Same URL renders `HomePage`; links resolve to `/Project-save-me-of-the-riwi/explore`, etc. Deep-link refresh works via the existing `404.html` fallback. (Will be verifiable on production once this merges through to `main` and the Pages workflow deploys.)

## How to Test

1. Pull the branch
2. Run `pnpm install`
3. Run `pnpm vitest run src/presentation/routes/router.spec.tsx` — 5 tests pass
4. Simulate Pages locally: `CINETECA_BASE_PATH=/cineteca/ pnpm build && CINETECA_BASE_PATH=/cineteca/ pnpm vite preview --outDir dist` then visit `http://localhost:4173/cineteca/` — home renders, links stay under `/cineteca`
5. Verify dev is unchanged: `pnpm dev` → app at `/` as before

## Tests

- [x] I added unit tests for the new logic
- [x] I updated existing tests that no longer apply
- [x] I verified the manual test plan above
- [x] Coverage has not decreased

## Quality Gate

Ran `bash scripts/verify.sh --full` on this branch — all green:

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm check-types` passes
- [x] `pnpm test` passes (58 files / 487 tests; coverage 91.13% stmts)
- [x] `pnpm build` succeeds
- [x] `./scripts/check-versions.sh` reports no deprecated deps

## Checklist

- [x] My code follows the project's architecture rules (domain is pure, dependencies point inward)
- [x] I have used the codebase's existing patterns and utilities
- [x] I have not introduced `any` without justification
- [x] I have not used `--no-verify` or weakened the gate
- [x] I have added comments only where the logic is non-obvious
- [x] I have updated the documentation (README, copy, etc.) if needed
- [x] I have read the [Cineteca Project Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cineteca.md) and the [Baseline Guide](https://github.com/Team-Centinela/Project-save-me-of-the-riwi/blob/main/Cin%C3%A9tica%20BaseLine.md)

## Deployment Notes

- None. Dev behavior is unchanged (`BASE_URL` is `/`); the fix only takes effect in builds where `CINETECA_BASE_PATH` is set by the deploy workflow.

---

> By submitting this pull request, I confirm that my contribution is made under the project's license and that I have the right to submit it.
